### PR TITLE
Fix building in C++Builder.

### DIFF
--- a/jvcl/run/JvPrvwDoc.pas
+++ b/jvcl/run/JvPrvwDoc.pas
@@ -142,8 +142,8 @@ type
     function MMToXPx(MM: Single): Integer;
     function MMToYPx(MM: Single): Integer;
     property OnChange: TNotifyEvent read FOnChange write FOnChange;
-  published
     property ReferenceHandle: HDC read FReferenceHandle write SetReferenceHandle;
+  published
     property LogPixelsX: Cardinal read FLogPixelsX write SetLogPixesX;
     property LogPixelsY: Cardinal read FLogPixelsY write SetLogPixelsY;
     property PhysicalWidth: Cardinal read FPhysicalWidth write SetPhysicalWidth;


### PR DESCRIPTION
C++Builder doesn't like trying to publish an HDC.  (This may only show up if #define STRICT was used.)
