### PR TITLE
Update JvDesignImp.pas

### DIFF
--- a/jvcl/run/JvDesignImp.pas
+++ b/jvcl/run/JvDesignImp.pas
@@ -205,6 +205,7 @@ type
     // IDesignerNotify interface
     procedure Modified;
     procedure Notification(AnObject: TPersistent; Operation: TOperation); reintroduce;
+    procedure CanInsertComponent(AComponent: TComponent);
 
     // IDesigner, IDesignerHook interface
     function GetCustomForm: TCustomForm;
@@ -1259,6 +1260,11 @@ end;
 
 procedure TJvDesignDesigner.Notification(AnObject: TPersistent;
   Operation: TOperation);
+begin
+  //
+end;
+
+procedure TJvDesignDesigner.CanInsertComponent(AComponent: TComponent);
 begin
   //
 end;


### PR DESCRIPTION
CanInsertComponent is needed for Delphi XE7, there it can be found in interface IDesignerNotify. This method was added in XE7.
As it simply is not used in older versions of Delphi, we only have to add it without taking steps for previous versions.
