### PR TITLE
Fix build on XE2+

### DIFF
--- a/jvcl/run/JvToolEdit.pas
+++ b/jvcl/run/JvToolEdit.pas
@@ -1157,9 +1157,9 @@ uses
   UxTheme,
   {$ENDIF HAS_UNIT_UXTHEME}
   {$ENDIF JVCLThemesEnabled}
-  {$IFDEF HAS_UNIT_VCL_THEMES} // VCL-Styles support
+  {$IFDEF COMPILER16_UP} // VCL-Styles support
   Vcl.Themes,
-  {$ENDIF HAS_UNIT_VCL_THEMES}
+  {$ENDIF COMPILER16_UP}
   JclSysInfo, JclFileUtils, JclStrings,
   JvPickDate, JvJCLUtils, JvJVCLUtils,
   JvThemes, JvResources, JclSysUtils;


### PR DESCRIPTION
on XE2+
code
  {$IFDEF COMPILER16_UP}
  ColorStates: array[Boolean] of TStyleColor = (scEditDisabled, scEdit);
  FontColorStates: array[Boolean] of TStyleFont = (sfEditBoxTextDisabled, sfEditBoxTextNormal);
  {$ENDIF COMPILER16_UP}

use type from VCL.Themes
