### PR TITLE
Fix DeleteSubTree to work with sub storages

### DIFF
--- a/jvcl/run/JvAppStorage.pas
+++ b/jvcl/run/JvAppStorage.pas
@@ -2132,7 +2132,7 @@ var
 begin
   ResolvePath(Path, TargetStore, TargetPath);
   if not TargetStore.ReadOnly then
-    TargetStore.DeleteSubTreeInt(Path);
+    TargetStore.DeleteSubTreeInt(TargetPath);
 end;
 
 function TJvCustomAppStorage.ReadInteger(const Path: string; Default: Integer): Integer;


### PR DESCRIPTION
Passing to TargetStore.DeleteSubTreeInt() value that is correct for sub storages.