### PR TITLE
Fix JvGnugettext.hpp

### DIFF
--- a/jvcl/run/JvGnugettext.pas
+++ b/jvcl/run/JvGnugettext.pas
@@ -473,7 +473,9 @@ type
 
 const
   LOCALE_SISO639LANGNAME = $59;    // Used by Lazarus software development tool
+  {$NODEFINE LOCALE_SISO639LANGNAME}
   LOCALE_SISO3166CTRYNAME = $5A;   // Used by Lazarus software development tool
+  {$NODEFINE LOCALE_SISO3166CTRYNAME }
 
 var
   DefaultInstance:TGnuGettextInstance;  /// Default instance of the main API for singlethreaded applications.


### PR DESCRIPTION
`LOCALE_SISO639LANGNAME` and `LOCALE_SISO3166CTRYNAME` are #defines within winnls.h, so trying to treat them as symbols in JvGnugettext.hpp will fail.