### PR TITLE
TJvMemoryData improvement & Fixed TJvDockSplitterStyle.MinSize being ignored

### DIFF
--- a/jvcl/run/JvDockControlForm.pas
+++ b/jvcl/run/JvDockControlForm.pas
@@ -4677,6 +4677,7 @@ procedure TJvDockSplitterStyle.AssignToSplitter(Dest: TJvDockSplitter);
 begin
   Dest.Color := Color;
   Dest.Cursor := Cursor;
+  Dest.MinSize := MinSize;
   Dest.ParentColor := ParentColor;
   Dest.ResizeStyle := ResizeStyle;
   if Dest.Align in [alTop, alBottom] then

--- a/jvcl/run/JvMemoryDataset.pas
+++ b/jvcl/run/JvMemoryDataset.pas
@@ -1603,8 +1603,9 @@ begin
       SetAutoIncFields(PJvMemBuffer(ActiveBuffer));
     if FRecordPos >= FRecords.Count then
     begin
-      SetMemoryRecordData(PJvMemBuffer(ActiveBuffer), AddRecord.Index);
+      AddRecord;
       FRecordPos := FRecords.Count - 1;
+      SetMemoryRecordData(PJvMemBuffer(ActiveBuffer), FRecordPos);
     end
     else
     begin


### PR DESCRIPTION
The improvement references a post on the JEDI forum from a few months back: http://newsportal.delphi-jedi.org/article.php?id=1428&group=jedi.jvcl

The second was a bug we noticed a while back regarding the MinSize seemingly being ignored in the TJvDockServer's 4 TJvDockSplitterStyle properties.