### PR TITLE
Fixed key press search functionality for TJvPopupListBox

### DIFF
--- a/jvcl/run/JvComponent.pas
+++ b/jvcl/run/JvComponent.pas
@@ -75,7 +75,7 @@ type
   TJvPopupListBox = class(TJvExCustomListBox)
   private
     FSearchText: string;
-    FSearchTickCount: Longint;
+    FSearchTickCount: Int64;
   protected
     procedure CreateParams(var Params: TCreateParams); override;
     procedure CreateWnd; override;
@@ -243,7 +243,7 @@ begin
         TickCount := GetTickCount;
         if TickCount < FSearchTickCount then
           Inc(TickCount, $100000000); // (ahuser) reduces the overflow
-        if TickCount - FSearchTickCount >= 4000 then
+        if ((TickCount - FSearchTickCount >= 4000) and (FSearchText <> '')) then
           FSearchText := '';
         FSearchTickCount := TickCount;
         if Length(FSearchText) < 32 then


### PR DESCRIPTION
No key presses were being added to FSearchText.

First key press was being ignored due to FSearchTickCount not being initialized.

TickCount and FSearchTickCount were not of the same data type which meant that when FSearchTickCount was assigned it was not the value it should have been. This caused each key press to be outside the 4000ms timeout and hence be ignored.