### PR TITLE
Changes for 10.3 Rio

### DIFF
--- a/jvcl/run/JvAppIniStorage.pas
+++ b/jvcl/run/JvAppIniStorage.pas
@@ -235,7 +235,7 @@ end;
   Note that this is a dirty hack, a better way would be to rewrite TMemIniFile;
   especially expose FSections. }
 {$IFDEF DELPHI2009_UP}
-{$if CompilerVersion <= 32}
+{$IFNDEF RTL330_UP}
 { with Delphi 10.3 Rio TMemIniFile was rewritten, so there is no need for
   optimization any more as dictionaries are used now }
 type
@@ -267,7 +267,7 @@ begin
   end else
     Result := False;
 end;
-{$ifend}
+{$ENDIF RTL330_UP}
 {$ELSE}
 type
   TJvMemIniFile = class(TMemIniFile)

--- a/jvcl/run/JvAppIniStorage.pas
+++ b/jvcl/run/JvAppIniStorage.pas
@@ -235,6 +235,9 @@ end;
   Note that this is a dirty hack, a better way would be to rewrite TMemIniFile;
   especially expose FSections. }
 {$IFDEF DELPHI2009_UP}
+{$if CompilerVersion <= 32}
+{ with Delphi 10.3 Rio TMemIniFile was rewritten, so there is no need for
+  optimization any more as dictionaries are used now }
 type
   /// Optimization: TMemIniFile should overwrite these methods by itself
   TMemIniFileHelper = class helper for TMemIniFile
@@ -264,6 +267,7 @@ begin
   end else
     Result := False;
 end;
+{$ifend}
 {$ELSE}
 type
   TJvMemIniFile = class(TMemIniFile)

--- a/jvcl/run/JvListComb.pas
+++ b/jvcl/run/JvListComb.pas
@@ -42,6 +42,9 @@ uses
   {$IFDEF UNITVERSIONING}
   JclUnitVersioning,
   {$ENDIF UNITVERSIONING}
+  {$IFDEF RTL260_UP}
+  System.Generics.Collections,
+  {$ENDIF RTL260_UP}
   Windows, Messages,
   SysUtils, Classes, Graphics, Controls, ExtCtrls, StdCtrls, ImgList,
   JvJCLUtils, JvCombobox,

--- a/jvcl/run/JvScheduledEvents.pas
+++ b/jvcl/run/JvScheduledEvents.pas
@@ -35,6 +35,9 @@ uses
   {$IFDEF UNITVERSIONING}
   JclUnitVersioning,
   {$ENDIF UNITVERSIONING}
+  {$IFDEF RTL260_UP}
+  System.Generics.Collections,
+  {$ENDIF RTL260_UP}
   SysUtils, Classes, Contnrs, SyncObjs,
   {$IFDEF MSWINDOWS}
   Windows,

--- a/jvcl/run/JvSimScope.pas
+++ b/jvcl/run/JvSimScope.pas
@@ -49,6 +49,9 @@ uses
   {$IFDEF UNITVERSIONING}
   JclUnitVersioning,
   {$ENDIF UNITVERSIONING}
+  {$IFDEF RTL260_UP}
+  System.Generics.Collections,
+  {$ENDIF RTL260_UP}
   Windows, Messages, SysUtils, Classes,
   Graphics, Controls, Forms, ExtCtrls;
 

--- a/jvcl/run/JvTabBar.pas
+++ b/jvcl/run/JvTabBar.pas
@@ -33,6 +33,9 @@ uses
   {$IFDEF UNITVERSIONING}
   JclUnitVersioning,
   {$ENDIF UNITVERSIONING}
+  {$IFDEF RTL260_UP}
+  System.Generics.Collections,
+  {$ENDIF RTL260_UP}
   Windows, Messages, Graphics, Controls, Forms, ImgList, Menus, Buttons,
   ExtCtrls,
   SysUtils, Classes, Contnrs,

--- a/jvcl/run/JvTimerList.pas
+++ b/jvcl/run/JvTimerList.pas
@@ -54,6 +54,9 @@ uses
   {$IFDEF UNITVERSIONING}
   JclUnitVersioning,
   {$ENDIF UNITVERSIONING}
+  {$IFDEF RTL260_UP}
+  System.Generics.Collections,
+  {$ENDIF RTL260_UP}
   Windows, Messages, SysUtils, Classes;
 
 const


### PR DESCRIPTION
When trying to compile for Rio errors occured, which are fixed with these changes.