### PR TITLE
Add the ability to create a 'lookup like' picklist, even when FieldKind <> fkLookup

### DIFF
--- a/jvcl/examples/JvDBGridLookup/MainU.dfm
+++ b/jvcl/examples/JvDBGridLookup/MainU.dfm
@@ -1,0 +1,191 @@
+object Form1: TForm1
+  Left = 0
+  Top = 0
+  Caption = 'Form1'
+  ClientHeight = 485
+  ClientWidth = 673
+  Color = clBtnFace
+  Font.Charset = DEFAULT_CHARSET
+  Font.Color = clWindowText
+  Font.Height = -11
+  Font.Name = 'Tahoma'
+  Font.Style = []
+  OldCreateOrder = False
+  OnCreate = FormCreate
+  PixelsPerInch = 96
+  TextHeight = 13
+  object JvDBGrid1: TJvDBGrid
+    Left = 0
+    Top = 0
+    Width = 673
+    Height = 485
+    Align = alClient
+    DataSource = dsItems
+    Options = [dgEditing, dgAlwaysShowEditor, dgTitles, dgIndicator, dgColumnResize, dgColLines, dgRowLines, dgTabs, dgConfirmDelete, dgCancelOnExit, dgTitleClick, dgTitleHotTrack]
+    TabOrder = 0
+    TitleFont.Charset = DEFAULT_CHARSET
+    TitleFont.Color = clWindowText
+    TitleFont.Height = -11
+    TitleFont.Name = 'Tahoma'
+    TitleFont.Style = []
+    SelectColumnsDialogStrings.Caption = 'Select columns'
+    SelectColumnsDialogStrings.OK = '&OK'
+    SelectColumnsDialogStrings.NoSelectionWarning = 'At least one column must be visible!'
+    EditControls = <>
+    RowsHeight = 17
+    TitleRowHeight = 17
+  end
+  object cdsItems: TClientDataSet
+    Active = True
+    Aggregates = <>
+    FieldDefs = <
+      item
+        Name = 'ID'
+        DataType = ftInteger
+      end
+      item
+        Name = 'OMSCHR'
+        DataType = ftString
+        Size = 20
+      end
+      item
+        Name = 'LISTTYPE'
+        DataType = ftInteger
+      end
+      item
+        Name = 'LISTID'
+        DataType = ftInteger
+      end>
+    IndexDefs = <>
+    Params = <>
+    StoreDefs = True
+    AfterOpen = cdsItemsAfterOpen
+    Left = 80
+    Top = 88
+    Data = {
+      600000009619E0BD010000001800000004000000000003000000600002494404
+      00010000000000064F4D53434852010049000000010005574944544802000200
+      1400084C495354545950450400010000000000064C4953544944040001000000
+      00000000}
+    object cdsItemsID: TIntegerField
+      FieldName = 'ID'
+    end
+    object cdsItemsOMSCHR: TStringField
+      FieldName = 'OMSCHR'
+    end
+    object cdsItemsLISTTYPE: TIntegerField
+      Alignment = taLeftJustify
+      FieldName = 'LISTTYPE'
+      LookupDataSet = cdsListTypes
+      LookupKeyFields = 'ID'
+      LookupResultField = 'OMSCHR'
+      KeyFields = 'LISTTYPE'
+      OnGetText = cdsItemsLISTTYPEGetText
+    end
+    object cdsItemsLISTID: TIntegerField
+      Alignment = taLeftJustify
+      FieldName = 'LISTID'
+      LookupKeyFields = 'ID'
+      LookupResultField = 'OMSCHR'
+      KeyFields = 'LISTID'
+      OnGetText = cdsItemsLISTIDGetText
+    end
+  end
+  object dsItems: TDataSource
+    DataSet = cdsItems
+    OnDataChange = dsItemsDataChange
+    Left = 80
+    Top = 144
+  end
+  object cdsList1: TClientDataSet
+    Active = True
+    Aggregates = <>
+    FieldDefs = <
+      item
+        Name = 'ID'
+        DataType = ftInteger
+      end
+      item
+        Name = 'OMSCHR'
+        DataType = ftString
+        Size = 20
+      end
+      item
+        Name = 'EX'
+        DataType = ftString
+        Size = 20
+      end>
+    IndexDefs = <>
+    Params = <>
+    StoreDefs = True
+    AfterOpen = cdsList1AfterOpen
+    Left = 232
+    Top = 104
+    Data = {
+      570000009619E0BD010000001800000003000000000003000000570002494404
+      00010000000000064F4D53434852010049000000010005574944544802000200
+      140002455801004900000001000557494454480200020014000000}
+    object cdsList1ID: TIntegerField
+      FieldName = 'ID'
+    end
+    object cdsList1OMSCHR: TStringField
+      FieldName = 'OMSCHR'
+    end
+    object cdsList1EX: TStringField
+      FieldName = 'EX'
+    end
+  end
+  object cdsList2: TClientDataSet
+    Active = True
+    Aggregates = <>
+    Params = <>
+    AfterOpen = cdsList2AfterOpen
+    Left = 232
+    Top = 168
+    Data = {
+      400000009619E0BD010000001800000002000000000003000000400002494404
+      00010000000000064F4D53434852010049000000010005574944544802000200
+      14000000}
+    object IntegerField1: TIntegerField
+      FieldName = 'ID'
+    end
+    object StringField1: TStringField
+      FieldName = 'OMSCHR'
+    end
+  end
+  object cdsListTypes: TClientDataSet
+    Active = True
+    Aggregates = <>
+    FieldDefs = <
+      item
+        Name = 'ID'
+        DataType = ftInteger
+      end
+      item
+        Name = 'OMSCHR'
+        DataType = ftString
+        Size = 20
+      end
+      item
+        Name = 'EX'
+        DataType = ftString
+        Size = 20
+      end>
+    IndexDefs = <>
+    Params = <>
+    StoreDefs = True
+    AfterOpen = cdsListTypesAfterOpen
+    Left = 152
+    Top = 88
+    Data = {
+      570000009619E0BD010000001800000003000000000003000000570002494404
+      00010000000000064F4D53434852010049000000010005574944544802000200
+      140002455801004900000001000557494454480200020014000000}
+    object IntegerField2: TIntegerField
+      FieldName = 'ID'
+    end
+    object StringField2: TStringField
+      FieldName = 'OMSCHR'
+    end
+  end
+end

--- a/jvcl/examples/JvDBGridLookup/MainU.dfm
+++ b/jvcl/examples/JvDBGridLookup/MainU.dfm
@@ -11,7 +11,6 @@ object Form1: TForm1
   Font.Name = 'Tahoma'
   Font.Style = []
   OldCreateOrder = False
-  OnCreate = FormCreate
   PixelsPerInch = 96
   TextHeight = 13
   object JvDBGrid1: TJvDBGrid
@@ -34,6 +33,7 @@ object Form1: TForm1
     EditControls = <>
     RowsHeight = 17
     TitleRowHeight = 17
+    OnGetColumnLookupInfo = JvDBGrid1GetColumnLookupInfo
   end
   object cdsItems: TClientDataSet
     Active = True

--- a/jvcl/examples/JvDBGridLookup/MainU.pas
+++ b/jvcl/examples/JvDBGridLookup/MainU.pas
@@ -35,11 +35,10 @@ type
     procedure cdsList1AfterOpen(DataSet: TDataSet);
     procedure cdsList2AfterOpen(DataSet: TDataSet);
     procedure cdsListTypesAfterOpen(DataSet: TDataSet);
-    procedure DoGetColumnLookupInfo(Sender: TObject; Column: TColumn; var
-        LookupInfo: TJvDBGridColumnLookupInfo);
     procedure dsItemsDataChange(Sender: TObject; Field: TField);
-    procedure FormCreate(Sender: TObject);
     function GetLookupDsByType(aType: Integer): TDataset;
+    procedure JvDBGrid1GetColumnLookupInfo(Sender: TObject; Column: TColumn; var
+        LookupInfo: TJvDBGridColumnLookupInfo);
   end;
 
 var
@@ -106,26 +105,10 @@ begin
   DataSet.AppendRecord([2, 'List 2']);
 end;
 
-procedure TForm1.DoGetColumnLookupInfo(Sender: TObject; Column: TColumn; var
-    LookupInfo: TJvDBGridColumnLookupInfo);
-begin
-  if Column.Field = cdsItemsLISTID then
-  begin
-    LookupInfo.IsLookup := True;
-    LookupInfo.LookupDataSet := GetLookupDsByType(cdsItemsLISTTYPE.AsInteger);
-  end else
-    LookupInfo.IsLookup := Column.Field.KeyFields > '';
-end;
-
 procedure TForm1.dsItemsDataChange(Sender: TObject; Field: TField);
 begin
   if (Field = cdsItemsLISTTYPE) and (not cdsItemsLISTID.IsNull) then
     cdsItemsLISTID.Clear;
-end;
-
-procedure TForm1.FormCreate(Sender: TObject);
-begin
-  JvDBGrid1.OnGetColumnLookupInfo := DoGetColumnLookupInfo;
 end;
 
 function TForm1.GetLookupDsByType(aType: Integer): TDataset;
@@ -136,6 +119,17 @@ begin
   else
     Result := nil;
   end;
+end;
+
+procedure TForm1.JvDBGrid1GetColumnLookupInfo(Sender: TObject; Column: TColumn;
+    var LookupInfo: TJvDBGridColumnLookupInfo);
+begin
+  if Column.Field = cdsItemsLISTID then
+  begin
+    LookupInfo.IsLookup := True;
+    LookupInfo.LookupDataSet := GetLookupDsByType(cdsItemsLISTTYPE.AsInteger);
+  end else
+    LookupInfo.IsLookup := Column.Field.KeyFields > '';
 end;
 
 end.

--- a/jvcl/examples/JvDBGridLookup/MainU.pas
+++ b/jvcl/examples/JvDBGridLookup/MainU.pas
@@ -1,0 +1,141 @@
+unit MainU;
+
+interface
+
+uses
+  Winapi.Windows, Winapi.Messages, System.SysUtils, System.Variants, System.Classes,
+  Data.DB, Datasnap.DBClient,
+  Vcl.Graphics, Vcl.Controls, Vcl.Forms, Vcl.Dialogs, Vcl.Grids, Vcl.DBGrids,
+  JvExDBGrids, JvDBGrid;
+
+type
+  TForm1 = class(TForm)
+    cdsItems: TClientDataSet;
+    cdsItemsID: TIntegerField;
+    cdsItemsLISTID: TIntegerField;
+    cdsItemsLISTTYPE: TIntegerField;
+    cdsItemsOMSCHR: TStringField;
+    cdsList1: TClientDataSet;
+    cdsList1EX: TStringField;
+    cdsList1ID: TIntegerField;
+    cdsList1OMSCHR: TStringField;
+    cdsList2: TClientDataSet;
+    cdsListTypes: TClientDataSet;
+    dsItems: TDataSource;
+    IntegerField1: TIntegerField;
+    IntegerField2: TIntegerField;
+    JvDBGrid1: TJvDBGrid;
+    StringField1: TStringField;
+    StringField2: TStringField;
+    procedure cdsItemsAfterOpen(DataSet: TDataSet);
+    procedure cdsItemsLISTIDGetText(Sender: TField; var Text: string; DisplayText:
+        Boolean);
+    procedure cdsItemsLISTTYPEGetText(Sender: TField; var Text: string;
+        DisplayText: Boolean);
+    procedure cdsList1AfterOpen(DataSet: TDataSet);
+    procedure cdsList2AfterOpen(DataSet: TDataSet);
+    procedure cdsListTypesAfterOpen(DataSet: TDataSet);
+    procedure DoGetColumnLookupInfo(Sender: TObject; Column: TColumn; var
+        LookupInfo: TJvDBGridColumnLookupInfo);
+    procedure dsItemsDataChange(Sender: TObject; Field: TField);
+    procedure FormCreate(Sender: TObject);
+    function GetLookupDsByType(aType: Integer): TDataset;
+  end;
+
+var
+  Form1: TForm1;
+
+implementation
+
+uses
+  Vcl.DBCtrls;
+
+{$R *.dfm}
+
+{ TForm1 }
+
+procedure TForm1.cdsItemsAfterOpen(DataSet: TDataSet);
+begin
+  // Some demo records
+  DataSet.AppendRecord([1, 'Test 1', 1, 3]);
+  DataSet.AppendRecord([2, 'Test 2', 1, 2]);
+  DataSet.AppendRecord([3, 'Test 3', 2, 13]);
+  DataSet.AppendRecord([4, 'Test 4', 2, 12]);
+  DataSet.AppendRecord([5, 'Test 5', 2, 14]);
+end;
+
+procedure TForm1.cdsItemsLISTIDGetText(Sender: TField; var Text: string;
+    DisplayText: Boolean);
+var
+  ds: TDataset;
+begin
+  if not Sender.IsNull then
+  begin
+    ds := GetLookupDsByType(cdsItemsLISTTYPE.AsInteger);
+    if Assigned(ds) then
+      Text := VarToStr(ds.Lookup(Sender.LookupKeyFields, Sender.Value, Sender.LookupResultField));
+  end;
+end;
+
+procedure TForm1.cdsItemsLISTTYPEGetText(Sender: TField; var Text: string;
+    DisplayText: Boolean);
+begin
+  if not Sender.IsNull then
+    Text := VarToStr(Sender.LookupDataSet.Lookup(Sender.LookupKeyFields, Sender.Value, Sender.LookupResultField));
+end;
+
+procedure TForm1.cdsList1AfterOpen(DataSet: TDataSet);
+begin
+  DataSet.AppendRecord([1, 'L1-1']);
+  DataSet.AppendRecord([2, 'L1-2']);
+  DataSet.AppendRecord([3, 'L1-3']);
+  DataSet.AppendRecord([4, 'L1-4']);
+end;
+
+procedure TForm1.cdsList2AfterOpen(DataSet: TDataSet);
+begin
+  DataSet.AppendRecord([11, 'L2-1']);
+  DataSet.AppendRecord([12, 'L2-2']);
+  DataSet.AppendRecord([13, 'L2-3']);
+  DataSet.AppendRecord([14, 'L2-4']);
+end;
+
+procedure TForm1.cdsListTypesAfterOpen(DataSet: TDataSet);
+begin
+  DataSet.AppendRecord([1, 'List 1']);
+  DataSet.AppendRecord([2, 'List 2']);
+end;
+
+procedure TForm1.DoGetColumnLookupInfo(Sender: TObject; Column: TColumn; var
+    LookupInfo: TJvDBGridColumnLookupInfo);
+begin
+  if Column.Field = cdsItemsLISTID then
+  begin
+    LookupInfo.IsLookup := True;
+    LookupInfo.LookupDataSet := GetLookupDsByType(cdsItemsLISTTYPE.AsInteger);
+  end else
+    LookupInfo.IsLookup := Column.Field.KeyFields > '';
+end;
+
+procedure TForm1.dsItemsDataChange(Sender: TObject; Field: TField);
+begin
+  if (Field = cdsItemsLISTTYPE) and (not cdsItemsLISTID.IsNull) then
+    cdsItemsLISTID.Clear;
+end;
+
+procedure TForm1.FormCreate(Sender: TObject);
+begin
+  JvDBGrid1.OnGetColumnLookupInfo := DoGetColumnLookupInfo;
+end;
+
+function TForm1.GetLookupDsByType(aType: Integer): TDataset;
+begin
+  case aType of
+    1: Result := cdsList1;
+    2: Result := cdsList2;
+  else
+    Result := nil;
+  end;
+end;
+
+end.

--- a/jvcl/examples/JvDBGridLookup/TestDBGridLookup.dpr
+++ b/jvcl/examples/JvDBGridLookup/TestDBGridLookup.dpr
@@ -1,0 +1,16 @@
+program TestDBGridLookup;
+
+uses
+  Vcl.Forms,
+  MainU in 'MainU.pas' {Form1},
+  JvDBGrid in '..\..\run\JvDBGrid.pas',
+  JvDBGridSelectColumnForm in '..\..\run\JvDBGridSelectColumnForm.pas' {frmSelectColumn};
+
+{$R *.res}
+
+begin
+  Application.Initialize;
+  Application.MainFormOnTaskbar := True;
+  Application.CreateForm(TForm1, Form1);
+  Application.Run;
+end.


### PR DESCRIPTION
Add the ability to create a 'lookup like' picklist, even when FieldKind <> fkLookup.

- this allows you to have different lookup list for one field, based on another field
- I can create a demo if wanted...

NEW FUNCTIONALITY:

Basically, the lookup information (based on TField.FieldKind = fkLookup) is wrapped by a new routine (GetColumnLookupInfo), which gets the lookup information from the column field.

In addition, you can:
- hook the new 'OnGetColumnLookupInfo' event to specify the LookupInfo information
- override the GetColumnLookupInfo to specify the LookupInfo information

To ensure the picklist functionality is used 'GetEditStyle' is overridden.
As is 'CanEditModify', so the in-place editor will act like a 'lookup list' (like fkLookup)