### PR TITLE
Update for registering JPEG Graphics with signature FF D8

### DIFF
--- a/jvcl/run/JvJVCLUtils.pas
+++ b/jvcl/run/JvJVCLUtils.pas
@@ -7262,6 +7262,7 @@ begin
     RegisterGraphicSignature([1, 0], 0, TMetafile); // EMF
     RegisterGraphicSignature('JFIF', 6, TJPEGImage);
     RegisterGraphicSignature('Exif', 6 , TJPEGImage);
+    RegisterGraphicSignature([$FF, $D8], 0 , TJPEGImage);
     // NB! Registering these will add a requirement on having the JvMM package installed
     // Let users register these manually
     // RegisterGraphicSignature([$0A], 0, TJvPcx);


### PR DESCRIPTION
Some kind of jpeg image does not has the "JFIF" or "Exif" signature at stream offset 6 as procedure GraphicSignaturesNeeded currently expected. According to JPEG standard (https://en.wikipedia.org/wiki/JPEG), JPEG File MUST begins with magic number FF D8. So we can register FF D8 as JPEG Signature to solve this problem.