### PR TITLE
Update JvAppIniStorage.pas

### DIFF
--- a/jvcl/run/JvPropertyStorage.pas
+++ b/jvcl/run/JvPropertyStorage.pas
@@ -267,6 +267,12 @@ procedure TJvPropertyStorage.LoadAnyProperty(PropInfo: PPropInfo);
 begin
   try
     if (PropInfo <> nil) and (PropInfo.SetProc <> nil) then
+    // --- begin bugfix ---
+    // Even if is is a readonly property, it might be an object with read/write properties.
+    // So we need to load it anyway.
+    // if (PropInfo <> nil) and (PropInfo.SetProc <> nil) then
+    if (PropInfo <> nil) then
+    // --- end bugfix ---
       ReadProperty(AppStoragePath, GetItemName(PropInfo.Name), TPersistent(FObject), PropInfo.Name);
   except
     { ignore any exception }


### PR DESCRIPTION
Bugfix: Unrelated sections could be deleted if by chance they start with the section name to be deleted:

[bla\blub]
[bla\blubber]

Now delete [bla\blub]
-> Would also delete [bla\blubber]