### PR TITLE
Fix issue #6544 in JvToolEdit.pas

### DIFF
--- a/jvcl/common/jvcld25.inc
+++ b/jvcl/common/jvcld25.inc
@@ -29,7 +29,7 @@ Known Issues:
 {%hidden%}
 { The installer enables this define if you compile JVCL for Delphi and C++ Builder. It disables
   the class constructor/destructor support that is not supported by C++Builder. }
-{$DEFINE JVCL_GENERATE_CPP_PACKAGE_FILES}
+{.$DEFINE JVCL_GENERATE_CPP_PACKAGE_FILES}
 
 {%hidden%}
 { The installer enables this define if you compile JVCL for a Delphi edition that has

--- a/jvcl/common/jvcld25_x64.inc
+++ b/jvcl/common/jvcld25_x64.inc
@@ -29,7 +29,7 @@ Known Issues:
 {%hidden%}
 { The installer enables this define if you compile JVCL for Delphi and C++ Builder. It disables
   the class constructor/destructor support that is not supported by C++Builder. }
-{$DEFINE JVCL_GENERATE_CPP_PACKAGE_FILES}
+{.$DEFINE JVCL_GENERATE_CPP_PACKAGE_FILES}
 
 {%hidden%}
 { The installer enables this define if you compile JVCL for a Delphi edition that has

--- a/jvcl/common/jvcld26.inc
+++ b/jvcl/common/jvcld26.inc
@@ -29,7 +29,7 @@ Known Issues:
 {%hidden%}
 { The installer enables this define if you compile JVCL for Delphi and C++ Builder. It disables
   the class constructor/destructor support that is not supported by C++Builder. }
-{$DEFINE JVCL_GENERATE_CPP_PACKAGE_FILES}
+{.$DEFINE JVCL_GENERATE_CPP_PACKAGE_FILES}
 
 {%hidden%}
 { The installer enables this define if you compile JVCL for a Delphi edition that has

--- a/jvcl/common/jvcld26_x64.inc
+++ b/jvcl/common/jvcld26_x64.inc
@@ -29,7 +29,7 @@ Known Issues:
 {%hidden%}
 { The installer enables this define if you compile JVCL for Delphi and C++ Builder. It disables
   the class constructor/destructor support that is not supported by C++Builder. }
-{$DEFINE JVCL_GENERATE_CPP_PACKAGE_FILES}
+{.$DEFINE JVCL_GENERATE_CPP_PACKAGE_FILES}
 
 {%hidden%}
 { The installer enables this define if you compile JVCL for a Delphi edition that has

--- a/jvcl/run/JvBalloonHint.pas
+++ b/jvcl/run/JvBalloonHint.pas
@@ -1248,7 +1248,7 @@ begin
     Exit;
 
   {$IFDEF JVCLThemesEnabled}
-  if IsWinVista_UP and StyleServices.Enabled and FIsMultiLineMsg then
+  if IsWinVista_UP and StyleServices.Enabled then
     Region := CreateThemedRegion
   else
   {$ENDIF JVCLThemesEnabled}

--- a/jvcl/run/JvToolEdit.pas
+++ b/jvcl/run/JvToolEdit.pas
@@ -3124,10 +3124,16 @@ begin
 end;
 
 procedure TJvCustomComboEdit.SetShowCaret;
-const
-  CaretWidth: array [Boolean] of Integer = (1, 2);
+var
+  CaretWidth : Integer;
 begin
-  CreateCaret(Handle, 0, CaretWidth[fsBold in Font.Style], GetTextHeight);
+  if not SystemParametersInfo(SPI_GETCARETWIDTH, 0, @CaretWidth, 0) then
+  begin
+    CaretWidth := 1;
+    if fsBold in Font.Style then
+      Inc(CaretWidth);
+  end;
+  CreateCaret(Handle, 0, CaretWidth, GetTextHeight);
   ShowCaret(Handle);
 end;
 


### PR DESCRIPTION
Windows allows users to change the caret width (text cursor width) to more than the default 1 pixel. While all contols derived from TCustomEdit work as expected, TJvCustomComboEdit and descendants ignore the user's setting. I've fixed that in TJvCustomComboEdit.SetShowCaret().


