### PR TITLE
Create bitmap before trying to draw a pointer. 

### DIFF
--- a/jvcl/run/JvDialButton.pas
+++ b/jvcl/run/JvDialButton.pas
@@ -456,6 +456,7 @@ begin
   if APosition <> FPosition then
   begin
     FPosition := APosition;
+    BitmapNeeded;
     DrawPointer;
     Changed := True;
   end;


### PR DESCRIPTION
Fixes Mantis issue 6671 where creating the component in code and setting min, max or position before the component had a chance to paint itsself led to a crash because FBitmap was not assigned.

http://issuetracker.delphi-jedi.org/view.php?id=6671