### PR TITLE
Add TJvXPAccelChar definition

### DIFF
--- a/jvcl/run/JvXPCore.pas
+++ b/jvcl/run/JvXPCore.pas
@@ -122,6 +122,14 @@ type
     OfficeXP                            // OfficeXP theme
    );
 
+  TJvXPAccelChar =
+   (
+     acNormal = 0,                      // default
+     acHidePrefix = DT_HIDEPREFIX,
+     acNoPrefix   = DT_NOPREFIX,
+     acOnlyPrefix = DT_PREFIXONLY
+   );
+
   { baseclass for non-focusable component descendants. }
   TJvXPCustomComponent = class(TJvComponent);
 


### PR DESCRIPTION
First part of the JvXPRenderText and TJvXPCustomButton to support DT_HIDEPREFIX, DT_NOPREFIX, DT_PREFIXONLY when calling DrawText commit from the
"Couple of small enhancements to JvMemoryDataset and XPButton" pull request #55
