### PR TITLE
JvXPCoreUtils enhancement as part of the commits for the "JvXPRenderT…

### DIFF
--- a/jvcl/run/JvXPCoreUtils.pas
+++ b/jvcl/run/JvXPCoreUtils.pas
@@ -53,16 +53,22 @@ procedure JvXPDrawBoundLines(const ACanvas: TCanvas; const BoundLines: TJvXPBoun
 
 procedure JvXPConvertToGray2(Bitmap: TBitmap);
 procedure JvXPRenderText(const AParent: TControl; const ACanvas: TCanvas;
+  ACaption: TCaption; const AFont: TFont; const AEnabled: Boolean; AShowAccelChar: Boolean;
+  var ARect: TRect; AFlags: Integer); overload;
+procedure JvXPRenderText(const AParent: TControl; const ACanvas: TCanvas;
   ACaption: TCaption; const AFont: TFont; const AEnabled: Boolean; const AAccelCharType: TJvXPAccelChar;
-  var ARect: TRect; AFlags: Integer);
+  var ARect: TRect; AFlags: Integer); overload;
 procedure JvXPFrame3D(const ACanvas: TCanvas; const Rect: TRect;
   const TopColor, BottomColor: TColor; const Swapped: Boolean = False);
 procedure JvXPColorizeBitmap(Bitmap: TBitmap; const AColor: TColor);
 procedure JvXPSetDrawFlags(const AAlignment: TAlignment; const AWordWrap: Boolean;
   var Flags: Integer);
 procedure JvXPPlaceText(const AParent: TControl; const ACanvas: TCanvas;
+  const AText: TCaption; const AFont: TFont; const AEnabled: Boolean; AShowAccelChar: Boolean;
+  const AAlignment: TAlignment; const AWordWrap: Boolean; var Rect: TRect); overload;
+procedure JvXPPlaceText(const AParent: TControl; const ACanvas: TCanvas;
   const AText: TCaption; const AFont: TFont; const AEnabled: Boolean; const AAccelCharType: TJvXPAccelChar;
-  const AAlignment: TAlignment; const AWordWrap: Boolean; var Rect: TRect);
+  const AAlignment: TAlignment; const AWordWrap: Boolean; var Rect: TRect); overload;
 
 {$IFDEF UNITVERSIONING}
 const
@@ -284,6 +290,13 @@ begin
 end;
 
 procedure JvXPRenderText(const AParent: TControl; const ACanvas: TCanvas;
+  ACaption: TCaption; const AFont: TFont; const AEnabled: Boolean; AShowAccelChar: Boolean;
+  var ARect: TRect; AFlags: Integer);
+begin
+  JvXPRenderText(AParent, ACanvas, ACaption, AFont, AEnabled, acNormal, ARect, AFlags);
+end;
+
+procedure JvXPRenderText(const AParent: TControl; const ACanvas: TCanvas;
   ACaption: TCaption; const AFont: TFont; const AEnabled: Boolean; const AAccelCharType: TJvXPAccelChar;
   var ARect: TRect; AFlags: Integer);
 
@@ -378,6 +391,13 @@ begin
     Flags := Flags or DT_SINGLELINE
   else
     Flags := Flags or DT_WORDBREAK;
+end;
+
+procedure JvXPPlaceText(const AParent: TControl; const ACanvas: TCanvas;
+  const AText: TCaption; const AFont: TFont; const AEnabled: Boolean; AShowAccelChar: Boolean;
+  const AAlignment: TAlignment; const AWordWrap: Boolean; var Rect: TRect);
+begin
+  JvXPPlaceText(AParent, ACanvas, AText, AFont, AEnabled, acNormal, AAlignment, AWordWrap, Rect);
 end;
 
 procedure JvXPPlaceText(const AParent: TControl; const ACanvas: TCanvas; const AText: TCaption;

--- a/jvcl/run/JvXPCoreUtils.pas
+++ b/jvcl/run/JvXPCoreUtils.pas
@@ -53,7 +53,7 @@ procedure JvXPDrawBoundLines(const ACanvas: TCanvas; const BoundLines: TJvXPBoun
 
 procedure JvXPConvertToGray2(Bitmap: TBitmap);
 procedure JvXPRenderText(const AParent: TControl; const ACanvas: TCanvas;
-  ACaption: TCaption; const AFont: TFont; const AEnabled, AShowAccelChar: Boolean;
+  ACaption: TCaption; const AFont: TFont; const AEnabled: Boolean; const AAccelCharType: TJvXPAccelChar;
   var ARect: TRect; AFlags: Integer);
 procedure JvXPFrame3D(const ACanvas: TCanvas; const Rect: TRect;
   const TopColor, BottomColor: TColor; const Swapped: Boolean = False);
@@ -61,7 +61,7 @@ procedure JvXPColorizeBitmap(Bitmap: TBitmap; const AColor: TColor);
 procedure JvXPSetDrawFlags(const AAlignment: TAlignment; const AWordWrap: Boolean;
   var Flags: Integer);
 procedure JvXPPlaceText(const AParent: TControl; const ACanvas: TCanvas;
-  const AText: TCaption; const AFont: TFont; const AEnabled, AShowAccelChar: Boolean;
+  const AText: TCaption; const AFont: TFont; const AEnabled: Boolean; const AAccelCharType: TJvXPAccelChar;
   const AAlignment: TAlignment; const AWordWrap: Boolean; var Rect: TRect);
 
 {$IFDEF UNITVERSIONING}
@@ -284,7 +284,7 @@ begin
 end;
 
 procedure JvXPRenderText(const AParent: TControl; const ACanvas: TCanvas;
-  ACaption: TCaption; const AFont: TFont; const AEnabled, AShowAccelChar: Boolean;
+  ACaption: TCaption; const AFont: TFont; const AEnabled: Boolean; const AAccelCharType: TJvXPAccelChar;
   var ARect: TRect; AFlags: Integer);
 
   procedure DoDrawText;
@@ -293,11 +293,10 @@ procedure JvXPRenderText(const AParent: TControl; const ACanvas: TCanvas;
   end;
 
 begin
-  if (AFlags and DT_CALCRECT <> 0) and ((ACaption = '') or AShowAccelChar and
-    (ACaption[1] = '&') and (ACaption[2] = #0)) then
+  if (AFlags and DT_CALCRECT <> 0) and ((ACaption = '') or (((AAccelCharType = acNormal) or
+     (AAccelCharType = acOnlyPrefix)) and (ACaption[1] = '&') and (ACaption[2] = #0))) then
     ACaption := ACaption + ' ';
-  if not AShowAccelChar then
-    AFlags := AFlags or DT_NOPREFIX;
+  AFlags := AFlags or Ord(AAccelCharType);
   AFlags := AParent.DrawTextBiDiModeFlags(AFlags);
   with ACanvas do
   begin
@@ -382,7 +381,7 @@ begin
 end;
 
 procedure JvXPPlaceText(const AParent: TControl; const ACanvas: TCanvas; const AText: TCaption;
-  const AFont: TFont; const AEnabled, AShowAccelChar: Boolean; const AAlignment: TAlignment;
+  const AFont: TFont; const AEnabled: Boolean; const AAccelCharType: TJvXPAccelChar; const AAlignment: TAlignment;
   const AWordWrap: Boolean; var Rect: TRect);
 var
   Flags, DX, OH, OW: Integer;
@@ -390,7 +389,7 @@ begin
   OH := Rect.Bottom - Rect.Top;
   OW := Rect.Right - Rect.Left;
   JvXPSetDrawFlags(AAlignment, AWordWrap, Flags);
-  JvXPRenderText(AParent, ACanvas, AText, AFont, AEnabled, AShowAccelChar, Rect,
+  JvXPRenderText(AParent, ACanvas, AText, AFont, AEnabled, AAccelCharType, Rect,
     Flags or DT_CALCRECT);
   if AAlignment = taRightJustify then
     DX := OW - (Rect.Right + Rect.Left)
@@ -400,7 +399,7 @@ begin
   else
     DX := 0;
   OffsetRect(Rect, DX, (OH - Rect.Bottom) div 2);
-  JvXPRenderText(AParent, ACanvas, AText, AFont, AEnabled, AShowAccelChar, Rect, Flags);
+  JvXPRenderText(AParent, ACanvas, AText, AFont, AEnabled, AAccelCharType, Rect, Flags);
 end;
 
 {$IFDEF UNITVERSIONING}


### PR DESCRIPTION
Second part of the JvXPRenderText and TJvXPCustomButton to support DT_HIDEPREFIX, DT_NOPREFIX, DT_PREFIXONLY when calling DrawText commit from the
"Couple of small enhancements to JvMemoryDataset and XPButton" pull request #55