### PR TITLE
Adapt JvXPCheckCtrls to the changes made in earlier pull requests

### DIFF
--- a/jvcl/run/JvXPCheckCtrls.pas
+++ b/jvcl/run/JvXPCheckCtrls.pas
@@ -324,12 +324,12 @@ begin
     if BiDiMode = bdRightToLeft then
     begin
       Dec(Rect.Right, FCheckSize + 4 + Spacing);
-      JvXPPlaceText(Self, Canvas, Caption, Font, Enabled, True, taRightJustify, True, Rect)
+      JvXPPlaceText(Self, Canvas, Caption, Font, Enabled, acNormal, taRightJustify, True, Rect)
     end
     else
     begin
       Inc(Rect.Left, FCheckSize + 4 + Spacing);
-      JvXPPlaceText(Self, Canvas, Caption, Font, Enabled, True, taLeftJustify, True, Rect);
+      JvXPPlaceText(Self, Canvas, Caption, Font, Enabled, acNormal, taLeftJustify, True, Rect);
     end;
    end;
 end;


### PR DESCRIPTION
Forth part of the JvXPRenderText and TJvXPCustomButton to support DT_HIDEPREFIX, DT_NOPREFIX, DT_PREFIXONLY when calling DrawText commit from the
"Couple of small enhancements to JvMemoryDataset and XPButton" pull request #55