### PR TITLE
Fix exception raised when assiging empty TStrings to JvSpinEdit

### DIFF
--- a/jvcl/run/JvSpin.pas
+++ b/jvcl/run/JvSpin.pas
@@ -1352,7 +1352,10 @@ procedure TJvCustomSpinEdit.SetItems(const AValue: TStrings);
 begin
   FItems.Assign(AValue);
   Value := 0;
-  Text := FItems[0];
+  if FItems.Count = 0 then
+    Text := ''
+  else
+    Text := FItems[0];
 end;
 
 procedure TJvCustomSpinEdit.SetMaxValue(NewValue: Extended);


### PR DESCRIPTION
Mantis issue 6673:
[http://issuetracker.delphi-jedi.org/view.php?id=6673](url)