### PR TITLE
JvMemoryData: Check if Offset overflows before adding to it.

### DIFF
--- a/jvcl/run/JvMemoryDataset.pas
+++ b/jvcl/run/JvMemoryDataset.pas
@@ -809,6 +809,7 @@ var
   Offset: Word;
   Field: TField;
   FieldDefsUpdated: Boolean;
+  FieldLen: Word;
 begin
   if FieldDefs.Count = 0 then
   begin
@@ -833,7 +834,11 @@ begin
     begin
       FOffsets[I] := Offset;
       if FieldDefList[I].DataType in ftSupported - ftBlobTypes then
-        Inc(Offset, CalcFieldLen(FieldDefList[I].DataType, FieldDefList[I].Size) + 1);
+      begin
+        FieldLen := CalcFieldLen(FieldDefList[I].DataType, FieldDefList[I].Size);
+        if Offset + FieldLen + 1 <= high(Offset) then
+          Inc(Offset, FieldLen + 1);
+      end;
     end;
   finally
     FieldDefs.Updated := FieldDefsUpdated;


### PR DESCRIPTION
Proposed fix for Mantis issue 6570.
[http://issuetracker.delphi-jedi.org/view.php?id=6570](url)