### PR TITLE
JvInterpreter throws duplicate identifier on whatever the first identifier is

### DIFF
--- a/jvcl/run/JvInterpreter.pas
+++ b/jvcl/run/JvInterpreter.pas
@@ -7970,6 +7970,7 @@ begin
   if FAdapter.UnitExists(UnitName) then
     Exit;
   FAdapter.AddSrcUnit(FCurUnitName, '', '');
+  FAdapter.AddSrcUnit(UnitName, '', '');
   OldUnitName := FCurUnitName;
   OldSource := Source;
   PushState;


### PR DESCRIPTION
Proposed fix from Mantis issue 6485
[http://issuetracker.delphi-jedi.org/view.php?id=6485](url)