### PR TITLE
Fix thread deadlock condition in JvWaitingGradient/JvImagedrawThread

### DIFF
--- a/jvcl/run/JvImageDrawThread.pas
+++ b/jvcl/run/JvImageDrawThread.pas
@@ -91,9 +91,9 @@ begin
         if Terminated then
           Exit;
 
-        Synchronize(Draw);
       finally
         LeaveUnpauseableSection;
+        Synchronize(Draw);
       end;
     end;
   except


### PR DESCRIPTION
As reported and proposed in mantis 6642
[http://issuetracker.delphi-jedi.org/view.php?id=6642](url)