### PR TITLE
Add System.UITypes to uses for D2009 and up to suppres compiler hint regarding inlining

### DIFF
--- a/jvcl/run/JvgUtils.pas
+++ b/jvcl/run/JvgUtils.pas
@@ -153,6 +153,9 @@ implementation
 uses
   JvJCLUtils,
   ShlObj, Math,
+  {$IFDEF DELPHI2009_UP}
+  System.UITypes,
+  {$ENDIF}
   JvResources, JvConsts;
 
 { debug func }


### PR DESCRIPTION
The hint was seen when installing JVCL.