### PR TITLE
JVCreateProcess appears to be running forever.

### DIFF
--- a/jvcl/run/JvCreateProcess.pas
+++ b/jvcl/run/JvCreateProcess.pas
@@ -1342,7 +1342,7 @@ begin
     begin
       { http://support.microsoft.com/default.aspx?scid=kb;en-us;124121 }
       WaitForInputIdle(FProcessInfo.hProcess, INFINITE);
-      GotoRunningState;
+      GoToReadyState;
     end;
   finally
     { Close pipe handles (do not continue to modify the parent).


### PR DESCRIPTION
Implemented proposed fix from Mantis 6610:
It is better in this case to set the state as Ready instead of Running.

[http://issuetracker.delphi-jedi.org/view.php?id=6610](url)