### PR TITLE
TJvTFCustomGlance.CheckApptHint unconditionally expands ExtraDesc with CRLF

### DIFF
--- a/jvcl/run/JvTFGlance.pas
+++ b/jvcl/run/JvTFGlance.pas
@@ -2847,8 +2847,12 @@ var
   Handled: Boolean;
 begin
   if Assigned(FViewer) and FViewer.ShowSchedNamesInHint then
+  begin
     ExtraDesc := StringsToStr(SchedNames, ', ', False);
-  ExtraDesc := ExtraDesc + #13#10;
+    ExtraDesc := ExtraDesc + #13#10;
+  end
+  else
+    ExtraDesc := '';
 
   Handled := False;
   if Assigned(OnApptHint) then


### PR DESCRIPTION
Fix for Mantis issue 6579:
[http://issuetracker.delphi-jedi.org/view.php?id=6579](url)