### PR TITLE
Use TScreen.MenuFont instead of Canvas.Font in TJvMainMenu and TJvPopupMenu

### DIFF
--- a/jvcl/run/JvMenus.pas
+++ b/jvcl/run/JvMenus.pas
@@ -1255,7 +1255,7 @@ begin
         SaveIndex := SaveDC(hDC);
         try
           Canvas.Handle := hDC;
-          SetDefaultMenuFont(Canvas.Font);
+          SetDefaultMenuFont(TScreen.MenuFont);
           Canvas.Font.Color := clMenuText;
           Canvas.Brush.Color := clMenu;
           if mdDefault in State then
@@ -1836,7 +1836,7 @@ begin
         SaveIndex := SaveDC(hDC);
         try
           Canvas.Handle := hDC;
-          SetDefaultMenuFont(Canvas.Font);
+          SetDefaultMenuFont(TScreen.MenuFont);
           Canvas.Font.Color := clMenuText;
           Canvas.Brush.Color := clMenu;
           if mdDefault in State then


### PR DESCRIPTION
As proposed in mantis issue 6548
[http://issuetracker.delphi-jedi.org/view.php?id=6548](url)