### PR TITLE
Add System.UITypes to uses for D2009+ to suppress compiler hint... 

### DIFF
--- a/jvcl/run/JvgUtils.pas
+++ b/jvcl/run/JvgUtils.pas
@@ -153,6 +153,9 @@ implementation
 uses
   JvJCLUtils,
   ShlObj, Math,
+  {$IFDEF HAS_UNIT_SYSTEM_UITYPES}
+  System.UITypes,
+  {$ENDIF}
   JvResources, JvConsts;
 
 { debug func }


### PR DESCRIPTION
regarding inlining. Second attempt, this time using the requested define (I didn't knew yet).