### PR TITLE
JvHidControllerClass: added missing OnDataError event assignment in constructor

### DIFF
--- a/jvcl/run/JvHidControllerClass.pas
+++ b/jvcl/run/JvHidControllerClass.pas
@@ -806,6 +806,7 @@ begin
   FDataThread := nil;
   OnData := Controller.OnDeviceData;
   OnUnplug := Controller.OnDeviceUnplug;
+  OnDataError := Controller.OnDeviceDataError;
 
   FHidFileHandle := CreateFile(PChar(APnPInfo.DevicePath), GENERIC_READ or GENERIC_WRITE,
     FILE_SHARE_READ or FILE_SHARE_WRITE, nil, OPEN_EXISTING, 0, 0);


### PR DESCRIPTION
as suggest…ed in Mantis issue 6518.
[http://issuetracker.delphi-jedi.org/view.php?id=6518](url)