### PR TITLE
TJvValidateEdit: Return unsinged integer for dfHex, instead of singed integer 

### DIFF
--- a/jvcl/run/JvValidateEdit.pas
+++ b/jvcl/run/JvValidateEdit.pas
@@ -927,7 +927,7 @@ begin
     dfInteger, dfYear:
       Result := IntRangeValue(StrToIntDef(FEditText, 0));
     dfHex:
-      Result := IntRangeValue(StrToIntDef('$' + FEditText, 0));
+      Result := IntRangeValue(StrToUIntDef('$' + FEditText, 0));
     dfBcd:
       if TryStrToBcd(FEditText, Bcd) then
         Result := VarFMTBcdCreate(Bcd)


### PR DESCRIPTION
as the entry of a sign is already prevented elsewhere. Fix for Mantis issue 6497
[http://issuetracker.delphi-jedi.org/view.php?id=6497](url)