### PR TITLE
Fix the menu font in TJvMainMenu and TJvPopupMenu

### DIFF
--- a/jvcl/run/JvMenus.pas
+++ b/jvcl/run/JvMenus.pas
@@ -1255,7 +1255,7 @@ begin
         SaveIndex := SaveDC(hDC);
         try
           Canvas.Handle := hDC;
-          SetDefaultMenuFont(Canvas.Font);
+          SetDefaultMenuFont(Screen.MenuFont);
           Canvas.Font.Color := clMenuText;
           Canvas.Brush.Color := clMenu;
           if mdDefault in State then
@@ -1836,7 +1836,7 @@ begin
         SaveIndex := SaveDC(hDC);
         try
           Canvas.Handle := hDC;
-          SetDefaultMenuFont(Canvas.Font);
+          SetDefaultMenuFont(Screen.MenuFont);
           Canvas.Font.Color := clMenuText;
           Canvas.Brush.Color := clMenu;
           if mdDefault in State then


### PR DESCRIPTION
This time not calling a non existent class property/method. Replacement for pull request #101
Fix for Mantis issue 6548.
[http://issuetracker.delphi-jedi.org/view.php?id=6548](http://issuetracker.delphi-jedi.org/view.php?id=6548)