### PR TITLE
Fixed parsing error of <'body'><'b'>Paragraph<'/b'><'/body'>

### DIFF
--- a/jvcl/run/JvHtmlParser.pas
+++ b/jvcl/run/JvHtmlParser.pas
@@ -231,7 +231,7 @@ procedure TJvHTMLParser.AnalyseString(const Str: string);
 var
   Str2, Str3: string;
   StartTag1, StartTag2: string;
-  I, J, K, Index: Integer;
+  I, J, J1, K, Index: Integer;
   TagInfo: TTagInfo;
   AttributesList: TStringList;
 
@@ -334,7 +334,17 @@ begin
         while J <> 0 do
         begin
           // changed from StrSearch(case sensitive) to StrFind (case insensitive)
-          J := StrFind(StartTag1, Str, J);
+          if trim(StartTag2) = '' then
+          begin
+            J := StrFind(StartTag1, Str, J)
+          end
+          else
+          begin
+            J1 := J;
+            J := StrFind(StartTag1 + ' ', Str, J);
+            if J = 0 then
+             J := StrFind(StartTag1 + '>', Str, J1);
+          end;
           if J > 0 then
           begin
             // changed from StrSearch(case sensitive) to StrFind (case insensitive)


### PR DESCRIPTION
Delphi 7 and lower do not support UTF-8 source code, especially when there is a BOM at the beginning
Improved variant of #108 
Fix for Mantis issue 6527
[http://issuetracker.delphi-jedi.org/view.php?id=6527](http://issuetracker.delphi-jedi.org/view.php?id=6527)