### PR TITLE
JvMemoryData: Check if Offset overflows before adding to it.

### DIFF
--- a/jvcl/run/JvMemoryDataset.pas
+++ b/jvcl/run/JvMemoryDataset.pas
@@ -809,6 +809,7 @@ var
   Offset: Word;
   Field: TField;
   FieldDefsUpdated: Boolean;
+  FieldLen: Word;
 begin
   if FieldDefs.Count = 0 then
   begin
@@ -833,7 +834,13 @@ begin
     begin
       FOffsets[I] := Offset;
       if FieldDefList[I].DataType in ftSupported - ftBlobTypes then
-        Inc(Offset, CalcFieldLen(FieldDefList[I].DataType, FieldDefList[I].Size) + 1);
+      begin
+        FieldLen := CalcFieldLen(FieldDefList[I].DataType, FieldDefList[I].Size);
+        if Offset + FieldLen + 1 <= high(Offset) then
+          Inc(Offset, FieldLen + 1)
+        else
+          raise EIntOverflow.CreateResFmt(RsEFieldOffsetOverflow, [I]);
+      end;
     end;
   finally
     FieldDefs.Updated := FieldDefsUpdated;

--- a/jvcl/run/JvMemoryDataset.pas
+++ b/jvcl/run/JvMemoryDataset.pas
@@ -839,7 +839,7 @@ begin
         if Offset + FieldLen + 1 <= high(Offset) then
           Inc(Offset, FieldLen + 1)
         else
-          raise EIntOverflow.CreateResFmt(RsEFieldOffsetOverflow, [I]);
+          raise ERangeError.CreateResFmt(RsEFieldOffsetOverflow, [I]);
       end;
     end;
   finally

--- a/jvcl/run/JvResources.pas
+++ b/jvcl/run/JvResources.pas
@@ -1479,6 +1479,7 @@ resourcestring
   RsEUpdateError = 'Unable to modify the record.';
   // 'No se pudo eliminar el registro.';
   RsEDeleteError = 'Unable to erase the record.';
+  RsEFieldOffsetOverflow = 'Field offset overflow. Index: %0:d';
 
 //=== JvMouseGesture.pas =====================================================
 resourcestring


### PR DESCRIPTION
Improved version of #92 
Includes raising an exception and is hopefully good enough now.
Fix for Mantis issue 6570
[http://issuetracker.delphi-jedi.org/view.php?id=6570](http://issuetracker.delphi-jedi.org/view.php?id=6570)