### PR TITLE
JvToolEdit uses deprecated symbol SInvalidFilename in Rio

### DIFF
--- a/jvcl/run/JvToolEdit.pas
+++ b/jvcl/run/JvToolEdit.pas
@@ -5165,7 +5165,11 @@ begin
     ClearFileList;
   end
   else
+    {$IFDEF RTL330_UP}
+    raise EComboEditError.CreateResFmt(@SInvalidKnownFilename, [Value]);
+    {$ELSE}
     raise EComboEditError.CreateResFmt(@SInvalidFilename, [Value]);
+    {$ENDIF}
 end;
 
 function TJvFilenameEdit.GetFileName: TFileName;


### PR DESCRIPTION
 The compiler suggests to use SInvalidKnownFilename in 10.3 Rio. According to Peter Below the new constant was just added in Rio.
Fix for Mantis issue 6674
[http://issuetracker.delphi-jedi.org/view.php?id=6674](http://issuetracker.delphi-jedi.org/view.php?id=6674)