### PR TITLE
Fix warning about not being able to inline if UITypes is not in uses

### DIFF
--- a/jvcl/run/JvAni.pas
+++ b/jvcl/run/JvAni.pas
@@ -41,6 +41,9 @@ uses
   JclUnitVersioning,
   {$ENDIF UNITVERSIONING}
   Classes, RTLConsts, Windows, Graphics, Controls, ExtCtrls, Dialogs,
+  {$IFDEF HAS_UNIT_SYSTEM_UITYPES}
+  UITypes,
+  {$ENDIF}
   JvTypes;
 
 type

--- a/jvcl/run/JvAni.pas
+++ b/jvcl/run/JvAni.pas
@@ -42,7 +42,7 @@ uses
   {$ENDIF UNITVERSIONING}
   Classes, RTLConsts, Windows, Graphics, Controls, ExtCtrls, Dialogs,
   {$IFDEF HAS_UNIT_SYSTEM_UITYPES}
-  UITypes,
+  System.UITypes,
   {$ENDIF}
   JvTypes;
 


### PR DESCRIPTION
but implemented with the proper define instead of the suggested and dismissed one.
Improved variant of parts of pull request #50.