### PR TITLE
Get the ScreenWorkArea always from the screen the active window is on

### DIFF
--- a/jvcl/run/JvJVCLUtils.pas
+++ b/jvcl/run/JvJVCLUtils.pas
@@ -2291,7 +2291,7 @@ end;
 
 function ScreenWorkArea: TRect;
 begin
-  Result := Screen.MonitorFromWindow(Screen.ActiveForm.Handle).WorkareaRect;
+  Result := Screen.MonitorFromWindow(Screen.ActiveCustomForm.Handle).WorkareaRect;
 end;
 
 { Standard Windows MessageBox function }

--- a/jvcl/run/JvJVCLUtils.pas
+++ b/jvcl/run/JvJVCLUtils.pas
@@ -2291,10 +2291,7 @@ end;
 
 function ScreenWorkArea: TRect;
 begin
-  {$IFDEF MSWINDOWS}
-  if not SystemParametersInfo(SPI_GETWORKAREA, 0, @Result, 0) then
-  {$ENDIF MSWINDOWS}
-  Result := Bounds(0, 0, Screen.Width, Screen.Height);
+  Result := Screen.MonitorFromWindow(Screen.ActiveForm.Handle).WorkareaRect;
 end;
 
 { Standard Windows MessageBox function }


### PR DESCRIPTION
The old implementation always used the main screen/default screen.
Fix for Mantis issue 6419.
[http://issuetracker.delphi-jedi.org/view.php?id=6419](http://issuetracker.delphi-jedi.org/view.php?id=6419)