### PR TITLE
JvDBTreeview: Added ftLargeInto to the DefaultValidMasterFields list. 

### DIFF
--- a/jvcl/run/JvDBTreeView.pas
+++ b/jvcl/run/JvDBTreeView.pas
@@ -303,7 +303,7 @@ uses
 const
   DnDScrollArea = 15;
   DnDInterval = 200;
-  DefaultValidMasterFields = [ftSmallInt, ftInteger, ftAutoInc, ftWord, ftFloat, ftString, ftWideString, ftBCD, ftFMTBCD];
+  DefaultValidMasterFields = [ftSmallInt, ftInteger, ftLargeInt, ftAutoInc, ftWord, ftFloat, ftString, ftWideString, ftBCD, ftFMTBCD];
   DefaultValidDetailFields = DefaultValidMasterFields;
   DefaultValidItemFields = [ftString, ftWideString, ftMemo, ftFmtMemo, ftSmallInt, ftInteger, ftAutoInc,
     ftWord, ftBoolean, ftFloat, ftCurrency, ftDate, ftTime, ftDateTime, ftBCD, ftFMTBCD


### PR DESCRIPTION
This fixes the issue shown with the demo app attached to Mantis issue 6508.
[http://issuetracker.delphi-jedi.org/view.php?id=6508](http://issuetracker.delphi-jedi.org/view.php?id=6508)