### PR TITLE
JvTFDays: Map column under certain conditions not found

### DIFF
--- a/jvcl/run/JvTFDays.pas
+++ b/jvcl/run/JvTFDays.pas
@@ -6833,6 +6833,7 @@ var
   Coord: TJvTFDaysCoord;
 begin
   Cur := 0;
+  try
   with Msg do
     if HitTest = HTCLIENT then
     begin
@@ -6848,6 +6849,9 @@ begin
           Cur := Screen.Cursors[crDrag];
       end;
     end;
+ except
+    Cur := 0;
+  end;
 
   if Cur <> 0 then
     SetCursor(Cur)


### PR DESCRIPTION
Handle exceptions so it doesn't crash. Fix for acknowledged Mantis issue 6409.
[http://issuetracker.delphi-jedi.org/view.php?id=6409](http://issuetracker.delphi-jedi.org/view.php?id=6409)