### PR TITLE
Change TJvDBComboBox search to be case sensitive

### DIFF
--- a/jvcl/run/JvDBCombobox.pas
+++ b/jvcl/run/JvDBCombobox.pas
@@ -190,7 +190,7 @@ type
     property Text;
     property UpdateFieldImmediatelly: Boolean read FUpdateFieldImmediatelly write FUpdateFieldImmediatelly default False;
     property PreserveItemSelectionOnInsert: Boolean read FPreserveItemSelectionOnInsert write FPreserveItemSelectionOnInsert default False;
-    property CaseSensitiveSearch: Boolean read GetCaseSensitiveSearchValue write SetCaseSensitiveSearchValue default true;
+    property CaseSensitiveSearch: Boolean read GetCaseSensitiveSearchValue write SetCaseSensitiveSearchValue default false;
   end;
 
   {$IFDEF RTL230_UP}
@@ -306,7 +306,6 @@ begin
 
   FListSettings := TJvDBComboBoxListSettings.Create(Self);
   FValues := TStringList.Create;
-  FValues.CaseSensitive := True;
   FValues.OnChange := ValuesChanged;
   FEnableValues := True;
   Style := csDropDownList;

--- a/jvcl/run/JvDBCombobox.pas
+++ b/jvcl/run/JvDBCombobox.pas
@@ -243,7 +243,7 @@ type
     property UpdateFieldImmediatelly;
     property Values;
     property Visible;
-    property CaseSensitiveSearch;
+    property CaseSensitiveValues;
     property ListSettings; { should be published after Items and Values }
     property OnChange;
     property OnClick;
@@ -421,7 +421,7 @@ end;
 
 function TJvCustomDBComboBox.GetCaseSensitiveValues: Boolean;
 begin
-  result := FValues.CaseSensitive;
+  Result := FValues.CaseSensitive;
 end;
 
 function TJvCustomDBComboBox.GetComboText: string;

--- a/jvcl/run/JvDBCombobox.pas
+++ b/jvcl/run/JvDBCombobox.pas
@@ -143,8 +143,8 @@ type
     procedure CMGetDataLink(var Msg: TMessage); message CM_GETDATALINK;
     procedure WMPaint(var Msg: TWMPaint); message WM_PAINT;
     procedure SetListSettings(const Value: TJvDBComboBoxListSettings);
-    procedure SetCaseSensitiveSearchValue(Value: Boolean);
-    function GetCaseSensitiveSearchValue: Boolean;
+    procedure SetCaseSensitiveValues(Value: Boolean);
+    function GetCaseSensitiveValues: Boolean;
   protected
     function GetDataLink: TDataLink;
 
@@ -190,7 +190,7 @@ type
     property Text;
     property UpdateFieldImmediatelly: Boolean read FUpdateFieldImmediatelly write FUpdateFieldImmediatelly default False;
     property PreserveItemSelectionOnInsert: Boolean read FPreserveItemSelectionOnInsert write FPreserveItemSelectionOnInsert default False;
-    property CaseSensitiveValues: Boolean read GetCaseSensitiveSearchValue write SetCaseSensitiveSearchValue default false;
+    property CaseSensitiveValues: Boolean read GetCaseSensitiveValues write SetCaseSensitiveValues default false;
   end;
 
   {$IFDEF RTL230_UP}
@@ -375,7 +375,7 @@ begin
   FDataLink.Field.AsString := ComboText;
 end;
 
-procedure TJvCustomDBComboBox.SetCaseSensitiveSearchValue(Value: Boolean);
+procedure TJvCustomDBComboBox.SetCaseSensitiveValues(Value: Boolean);
 begin
   FValues.CaseSensitive := Value;
 end;
@@ -419,7 +419,7 @@ begin
   end;
 end;
 
-function TJvCustomDBComboBox.GetCaseSensitiveSearchValue: Boolean;
+function TJvCustomDBComboBox.GetCaseSensitiveValues: Boolean;
 begin
   result := FValues.CaseSensitive;
 end;

--- a/jvcl/run/JvDBCombobox.pas
+++ b/jvcl/run/JvDBCombobox.pas
@@ -143,6 +143,8 @@ type
     procedure CMGetDataLink(var Msg: TMessage); message CM_GETDATALINK;
     procedure WMPaint(var Msg: TWMPaint); message WM_PAINT;
     procedure SetListSettings(const Value: TJvDBComboBoxListSettings);
+    procedure SetCaseSensitiveSearchValue(Value: Boolean);
+    function GetCaseSensitiveSearchValue: Boolean;
   protected
     function GetDataLink: TDataLink;
 
@@ -188,6 +190,7 @@ type
     property Text;
     property UpdateFieldImmediatelly: Boolean read FUpdateFieldImmediatelly write FUpdateFieldImmediatelly default False;
     property PreserveItemSelectionOnInsert: Boolean read FPreserveItemSelectionOnInsert write FPreserveItemSelectionOnInsert default False;
+    property CaseSensitiveSearch: Boolean read GetCaseSensitiveSearchValue write SetCaseSensitiveSearchValue default true;
   end;
 
   {$IFDEF RTL230_UP}
@@ -240,6 +243,7 @@ type
     property UpdateFieldImmediatelly;
     property Values;
     property Visible;
+    property CaseSensitiveSearch;
     property ListSettings; { should be published after Items and Values }
     property OnChange;
     property OnClick;
@@ -302,6 +306,7 @@ begin
 
   FListSettings := TJvDBComboBoxListSettings.Create(Self);
   FValues := TStringList.Create;
+  FValues.CaseSensitive := True;
   FValues.OnChange := ValuesChanged;
   FEnableValues := True;
   Style := csDropDownList;
@@ -371,6 +376,11 @@ begin
   FDataLink.Field.AsString := ComboText;
 end;
 
+procedure TJvCustomDBComboBox.SetCaseSensitiveSearchValue(Value: Boolean);
+begin
+  FValues.CaseSensitive := Value;
+end;
+
 procedure TJvCustomDBComboBox.SetComboText(const Value: string);
 var
   I: Integer;
@@ -408,6 +418,11 @@ begin
     if Style in [csDropDown, csSimple] then
       Text := Value;
   end;
+end;
+
+function TJvCustomDBComboBox.GetCaseSensitiveSearchValue: Boolean;
+begin
+  result := FValues.CaseSensitive;
 end;
 
 function TJvCustomDBComboBox.GetComboText: string;

--- a/jvcl/run/JvDBCombobox.pas
+++ b/jvcl/run/JvDBCombobox.pas
@@ -190,7 +190,7 @@ type
     property Text;
     property UpdateFieldImmediatelly: Boolean read FUpdateFieldImmediatelly write FUpdateFieldImmediatelly default False;
     property PreserveItemSelectionOnInsert: Boolean read FPreserveItemSelectionOnInsert write FPreserveItemSelectionOnInsert default False;
-    property CaseSensitiveSearch: Boolean read GetCaseSensitiveSearchValue write SetCaseSensitiveSearchValue default false;
+    property CaseSensitiveValues: Boolean read GetCaseSensitiveSearchValue write SetCaseSensitiveSearchValue default false;
   end;
 
   {$IFDEF RTL230_UP}


### PR DESCRIPTION
Made search Key case sensitive by default but additionally provided a property to control this.
Fix for Mantis issue 6361.
[http://issuetracker.delphi-jedi.org/view.php?id=6361](http://issuetracker.delphi-jedi.org/view.php?id=6361)