### PR TITLE
Added System.UITypes to suppress compiler warnings about optimization

### DIFF
--- a/jvcl/run/JvDialButton.pas
+++ b/jvcl/run/JvDialButton.pas
@@ -37,6 +37,9 @@ uses
   {$IFDEF UNITVERSIONING}
   JclUnitVersioning,
   {$ENDIF UNITVERSIONING}
+  {$IFDEF HAS_UNIT_SYSTEM_UITYPES}
+  System.UITypes,
+  {$ENDIF}
   Windows, Messages, Classes, Graphics, Controls, Forms, ExtCtrls, ComCtrls,
   JvComponent;
 

--- a/jvcl/run/JvLinkLabelTextHandler.pas
+++ b/jvcl/run/JvLinkLabelTextHandler.pas
@@ -58,6 +58,9 @@ uses
   {$IFDEF UNITVERSIONING}
   JclUnitVersioning,
   {$ENDIF UNITVERSIONING}
+  {$IFDEF HAS_UNIT_SYSTEM_UITYPES}
+  System.UITypes,
+  {$ENDIF}
   Classes, SysUtils,
   Graphics, Windows,
   JvLinkLabelTree, JvLinkLabelTools, JvTypes;


### PR DESCRIPTION
Further units which emit optimization warnings due to missing System.UITypes in uses clause.