### PR TITLE
Change the way JvChangeNotify is informed about a directory change. 

### DIFF
--- a/jvcl/run/JvDriveCtrls.pas
+++ b/jvcl/run/JvDriveCtrls.pas
@@ -1686,7 +1686,11 @@ begin
   begin
     inherited ApplyFilePath(Value);
     if Assigned(FChangeNotify) and (FChangeNotify.Notifications.Count > 0) then
+    begin
+      FChangeNotify.Active := false;
       FChangeNotify.Notifications[0].Directory := Value;
+      FChangeNotify.Active := true;
+    end;
   end
   else
     // no directory defined any longer, so free change notification as well.

--- a/jvcl/run/JvDriveCtrls.pas
+++ b/jvcl/run/JvDriveCtrls.pas
@@ -1687,9 +1687,12 @@ begin
     inherited ApplyFilePath(Value);
     if Assigned(FChangeNotify) and (FChangeNotify.Notifications.Count > 0) then
     begin
-      FChangeNotify.Active := false;
-      FChangeNotify.Notifications[0].Directory := Value;
-      FChangeNotify.Active := true;
+      FChangeNotify.Active := False;
+      try
+        FChangeNotify.Notifications[0].Directory := Value;
+      finally
+        FChangeNotify.Active := True;
+      end;
     end;
   end
   else


### PR DESCRIPTION
At least a workaround to fix that it doesn't any longer auto update the file list if the .Directory property of the file list is being changed at runtime.
Fix for Mantis 6683:
[http://issuetracker.delphi-jedi.org/view.php?id=6683](http://issuetracker.delphi-jedi.org/view.php?id=6683)