### PR TITLE
Suppress warning about not possible to inline by adding System.Types,

### DIFF
--- a/jvcl/run/JvLinkLabelTextHandler.pas
+++ b/jvcl/run/JvLinkLabelTextHandler.pas
@@ -60,6 +60,7 @@ uses
   {$ENDIF UNITVERSIONING}
   {$IFDEF HAS_UNIT_SYSTEM_UITYPES}
   System.UITypes,
+  System.Types,
   {$ENDIF}
   Classes, SysUtils,
   Graphics, Windows,


### PR DESCRIPTION
Fixes a compiler warning/hint about impossible inlining due to missing System.Types.