### PR TITLE
Added System.UITypes.

### DIFF
--- a/jvcl/run/JvgButton.pas
+++ b/jvcl/run/JvgButton.pas
@@ -217,7 +217,11 @@ const
 implementation
 
 uses
-  JvConsts, JvJCLUtils, JvResources, JvThemes;
+  JvConsts, JvJCLUtils, JvResources,
+  {$IFDEF HAS_UNIT_SYSTEM_UITYPES}
+  System.UITypes,
+  {$ENDIF HAS_UNIT_SYSTEM_UITYPES}
+  JvThemes;
 
 {$R JvgButton.res}
 


### PR DESCRIPTION
JvgButton.pas was missing System.UITypes as well so the compiler warned about inlining not possible. Added it to implementation uses clause and it suppresses the warning as desired.