### PR TITLE
Speed improvement in SetText routine. First test looks ok.

### DIFF
--- a/jvcl/run/JvListComb.pas
+++ b/jvcl/run/JvListComb.pas
@@ -409,6 +409,9 @@ uses
   {$IFDEF RTL330_UP}
   System.Generics.Collections, // for TCollectionNotification items
   {$ENDIF RTL330_UP}
+  {$IFDEF HAS_UNIT_SYSTEM_UITYPES}
+  System.UITypes,
+  {$ENDIF}
   Math, JvJVCLUtils;
 
 type
@@ -576,7 +579,7 @@ begin
           Index := S.AddObject(Value, Self);
         end
         else
-          S[Index]:= value;
+          S[Index] := Value;
       finally
         FOwner := SavedOwner;
       end;

--- a/jvcl/run/JvListComb.pas
+++ b/jvcl/run/JvListComb.pas
@@ -570,15 +570,16 @@ begin
       SavedOwner := FOwner;
       try
         FOwner := nil;
-        S.Delete(Index);
         if (SavedOwner.GetOwner is TJvImageListBox) and (TJvImageListBox(SavedOwner.GetOwner).Sorted) then
-          S.AddObject(Value, Self)
+        begin
+          S.Delete(Index);
+          Index := S.AddObject(Value, Self);
+        end
         else
-          S.InsertObject(Index, Value, Self);
+          S[Index]:= value;
       finally
         FOwner := SavedOwner;
       end;
-      Index := S.IndexOfObject(Self);
       Change;
     end;
   end;


### PR DESCRIPTION
Based on this forum discussion (German) I created a pull request for the improved SetText method. I wrote a smallish test application which includes TStopwatch to measure the time and it indicates that the new version runs a few milliseconds faster (my test application clears the list and adds 130 items to it wrapped in Begin/Endupdate).

Discussion:
[https://www.delphipraxis.net/201871-massive-performanceprobleme-mit-tjvimagecombobox-4.html#post1446477](https://www.delphipraxis.net/201871-massive-performanceprobleme-mit-tjvimagecombobox-4.html#post1446477)