### PR TITLE
Use different resource string for newer Delphi versions 

### DIFF
--- a/jvcl/run/JvToolEdit.pas
+++ b/jvcl/run/JvToolEdit.pas
@@ -5165,7 +5165,13 @@ begin
     ClearFileList;
   end
   else
-    raise EComboEditError.CreateResFmt(@SInvalidFilename, [Value]);
+    raise EComboEditError.CreateResFmt(
+      {$IFDEF RTL330_UP}
+      @SInvalidKnownFilename,
+      {$ELSE}
+      @SInvalidFilename,
+      {$ENDIF RTL330_UP}
+      [Value]);
 end;
 
 function TJvFilenameEdit.GetFileName: TFileName;


### PR DESCRIPTION
in order to avoid a deprecation hint. Implemented as per discussion in the JVCL newsgroup