### PR TITLE
scientific numbers need at least one digit before the E/e scientific notation identifier

### DIFF
--- a/jvcl/run/JvInterpreterParser.pas
+++ b/jvcl/run/JvInterpreterParser.pas
@@ -501,10 +501,13 @@ begin
 
         Point := False;
         IsScientificNotation := False;
-        for I := 1 to L1 do
+        for I := 2 to L1 do
         begin
           Ci := Token[I];
-          if CharInSet(Ci, StConstE) then
+          // Scientific notation requires that before the E/e at least one digit
+          // is present
+          if CharInSet(Ci, StConstE) and
+             CharInSet(Token[I-1], StConstSymbols10) then
             IsScientificNotation := True;
 
           if Ci = '.' then

--- a/jvcl/run/JvInterpreterParser.pas
+++ b/jvcl/run/JvInterpreterParser.pas
@@ -501,12 +501,13 @@ begin
 
         Point := False;
         IsScientificNotation := False;
-        for I := 2 to L1 do
+        for I := 1 to L1 do
         begin
           Ci := Token[I];
           // Scientific notation requires that before the E/e at least one digit
-          // is present
-          if CharInSet(Ci, StConstE) and
+          // is present, so we can only begin checking from the 2nd char onwards
+          if (I > 1) and
+             CharInSet(Ci, StConstE) and
              CharInSet(Token[I-1], StConstSymbols10) then
             IsScientificNotation := True;
 


### PR DESCRIPTION
Improvement for pull request 115: 
somebody has found out that the change introduced by pull request #115 prevents the following coding style:

`try
   DoSomething;
 except
   on e:Exception
     DoSomethingElse;
 end;`

as e is always treated as scientific number now. Since such numbers need to have at least one single digit I created this new pull request with a proposed change. This is also being discussed in German Delphipraxis forum here:
[https://www.delphipraxis.net/205011-jedi-tjvinterpreterprogram-compile-exception-unter-10-4-sydney.html](https://www.delphipraxis.net/205011-jedi-tjvinterpreterprogram-compile-exception-unter-10-4-sydney.html)