### PR TITLE
Added property to TJvCustomDatePickerEdit to avoid exception raised on date error

### DIFF
--- a/jvcl/run/JvDBDatePickerEdit.pas
+++ b/jvcl/run/JvDBDatePickerEdit.pas
@@ -165,6 +165,7 @@ type
     property NoDateShortcut;
     property NoDateText;
     property NoDateValue;
+    property RaiseException;
     property NumGlyphs;
     property ParentColor;
     property ParentFont;

--- a/jvcl/run/JvDatePickerEdit.pas
+++ b/jvcl/run/JvDatePickerEdit.pas
@@ -145,7 +145,6 @@ type
     FDateSeparator: Char;
     FPopupDate: TDateTime;
     FNoDateValue: TDateTime;
-    FRaiseException: Boolean;
     FOnGetValidDateString: TJvGetValidDateStringEvent;
     //    FMinYear: Word;
     //    FMaxYear: Word;
@@ -232,7 +231,6 @@ type
     property NoDateShortcut: TShortcut read FNoDateShortcut write FNoDateShortcut stored IsNoDateShortcutStored;
     property NoDateText: string read FNoDateText write SetNoDateText stored IsNoDateTextStored;
     property NoDateValue: TDateTime read FNoDateValue write SetNoDateValue stored IsNoDateValueStored;
-    property RaiseException: Boolean read FRaiseException write FRaiseException default True;
     property ShowButton default True;
     property StoreDate: Boolean read FStoreDate write FStoreDate default False;
     property StoreDateFormat: Boolean read FStoreDateFormat write FStoreDateFormat default False;
@@ -662,7 +660,6 @@ begin
   //  FMinYear := 1800;
   FNoDateShortcut := TextToShortCut(RsDefaultNoDateShortcut);
   FNoDateText := '';
-  FRaiseException := True;
   FStoreDate := False;
   FStoreDateFormat := False;
 
@@ -783,7 +780,7 @@ begin
       begin
         FDateError := True;
         SetFocus;
-        if FRaiseException then
+        if RaiseException then
           raise;
       end
       else

--- a/jvcl/run/JvDatePickerEdit.pas
+++ b/jvcl/run/JvDatePickerEdit.pas
@@ -145,6 +145,7 @@ type
     FDateSeparator: Char;
     FPopupDate: TDateTime;
     FNoDateValue: TDateTime;
+    FRaiseException: Boolean;
     FOnGetValidDateString: TJvGetValidDateStringEvent;
     //    FMinYear: Word;
     //    FMaxYear: Word;
@@ -230,7 +231,8 @@ type
     //    property MinYear: Word read FMinYear write FMinYear;
     property NoDateShortcut: TShortcut read FNoDateShortcut write FNoDateShortcut stored IsNoDateShortcutStored;
     property NoDateText: string read FNoDateText write SetNoDateText stored IsNoDateTextStored;
-    property NoDateValue: TDateTime read FNoDateValue write SetNoDateValue stored IsNoDateValueStored; 
+    property NoDateValue: TDateTime read FNoDateValue write SetNoDateValue stored IsNoDateValueStored;
+    property RaiseException: Boolean read FRaiseException write FRaiseException default True;
     property ShowButton default True;
     property StoreDate: Boolean read FStoreDate write FStoreDate default False;
     property StoreDateFormat: Boolean read FStoreDateFormat write FStoreDateFormat default False;
@@ -660,6 +662,7 @@ begin
   //  FMinYear := 1800;
   FNoDateShortcut := TextToShortCut(RsDefaultNoDateShortcut);
   FNoDateText := '';
+  FRaiseException := True;
   FStoreDate := False;
   FStoreDateFormat := False;
 
@@ -780,7 +783,8 @@ begin
       begin
         FDateError := True;
         SetFocus;
-        raise;
+        if FRaiseException then
+          raise;
       end
       else
         Self.Date := NoDateValue;

--- a/jvcl/run/JvExMask.pas
+++ b/jvcl/run/JvExMask.pas
@@ -53,6 +53,7 @@ type
     FHintColor: TColor;
     FMouseOver: Boolean;
     FHintWindowClass: THintWindowClass;
+    FRaiseException: Boolean;
     FOnMouseEnter: TNotifyEvent;
     FOnMouseLeave: TNotifyEvent;
     FOnParentColorChanged: TNotifyEvent;
@@ -75,11 +76,13 @@ type
     function HitTest(X, Y: Integer): Boolean; reintroduce; virtual;
     procedure MouseEnter(AControl: TControl); reintroduce; dynamic;
     procedure MouseLeave(AControl: TControl); reintroduce; dynamic;
+    procedure ValidateError; override;
     property MouseOver: Boolean read FMouseOver write FMouseOver;
     property HintColor: TColor read FHintColor write FHintColor default clDefault;
     property OnMouseEnter: TNotifyEvent read FOnMouseEnter write FOnMouseEnter;
     property OnMouseLeave: TNotifyEvent read FOnMouseLeave write FOnMouseLeave;
     property OnParentColorChange: TNotifyEvent read FOnParentColorChanged write FOnParentColorChanged;
+    property RaiseException: Boolean read FRaiseException write FRaiseException default True;
   public
     constructor Create(AOwner: TComponent); override;
     property HintWindowClass: THintWindowClass read FHintWindowClass write FHintWindowClass;
@@ -259,6 +262,7 @@ begin
   FHintColor := clDefault;
   FClipboardCommands := [caCopy..caUndo];
   FBeepOnError := True;
+  FRaiseException := True;
   if UserTextHint then
     ControlState := ControlState + [csCustomPaint]; // needed for PaintWindow
 end;
@@ -280,6 +284,12 @@ end;
 function TJvExCustomMaskEdit.BaseWndProcEx(Msg: Cardinal; WParam: WPARAM; var StructLParam): LRESULT;
 begin
   Result := BaseWndProc(Msg, WParam, Windows.LPARAM(@StructLParam));
+end;
+
+procedure TJvExCustomMaskEdit.ValidateError;
+begin
+  if FRaiseException then
+    inherited;
 end;
 
 procedure TJvExCustomMaskEdit.VisibleChanged;


### PR DESCRIPTION
In TJvDBDatePickerEdit, if user manages to write an invalid date, as `50/50/2020`, EConvertError exception is raised with no option to be catched on exit from control, resulting in a message to user.

With new property `RaiseException` set as `False`, instead of message interruption, focus is maintained in control so user can understand that something is wrong with input.