### PR TITLE
Two modifications regaring JvAppStorage (BUG-fix + performance)

### DIFF
--- a/jvcl/run/JvAppIniStorage.pas
+++ b/jvcl/run/JvAppIniStorage.pas
@@ -704,7 +704,7 @@ begin
           IniFile.EraseSection(Sections[I])
       else
         for I := 0 to Sections.Count - 1 do
-          if Pos(TopSection, Sections[I]) = 1 then
+          if Pos(TopSection + '\', Sections[I] + '\') = 1 then
             IniFile.EraseSection(Sections[I]);
       FlushIfNeeded;
     finally

--- a/jvcl/run/JvAppStorage.pas
+++ b/jvcl/run/JvAppStorage.pas
@@ -2744,7 +2744,7 @@ begin
   if not Assigned(PersObj) then
     Exit;
 
-  P := GetPropInfo(PersObj, PropName, tkAny);
+  P := GetPropInfo(PersObj, PropName);
   T := PropType(PersObj, PropName);
   if T <> tkClass then
     if not Assigned(P.SetProc)  then
@@ -2759,7 +2759,7 @@ begin
     tkEnumeration:
       begin
         TmpValue := GetOrdProp(PersObj, PropName);
-        ReadEnumeration(Path, GetPropInfo(PersObj, PropName).PropType^, TmpValue, TmpValue);
+        ReadEnumeration(Path, P.PropType^, TmpValue, TmpValue);
         SetOrdProp(PersObj, PropName, TmpValue);
       end;
     tkVariant:
@@ -2767,13 +2767,13 @@ begin
     tkSet:
       begin
         TmpValue := GetOrdProp(PersObj, PropName);
-        ReadSet(Path, GetPropInfo(PersObj, PropName).PropType^, TmpValue, TmpValue);
+        ReadSet(Path, P.PropType^, TmpValue, TmpValue);
         SetOrdProp(PersObj, PropName, TmpValue);
       end;
     tkChar, tkWChar, tkInteger:
       begin
         TmpValue := GetOrdProp(PersObj, PropName);
-        ReadEnumeration(Path, GetPropInfo(PersObj, PropName).PropType^, TmpValue, TmpValue);
+        ReadEnumeration(Path, P.PropType^, TmpValue, TmpValue);
         SetOrdProp(PersObj, PropName, TmpValue);
       end;
     tkInt64:


### PR DESCRIPTION
BUG-FIX: JvAppIniStorage - TJvAppStorageIniFile.EraseSection
When you have the following section paths:
- Test\Test
- Test\Test\1
- Test\Test\2
- Test\Testing1
- Test\Testing2

Executing `storage.EraseSection('Test\Test')` will delete all sections instead of only the first 3 sections

Performance update: JvAppStorage
Only call `GetPropInfo` once and do not use 'tkAny' parameter