### PR TITLE
Change '\' to PathDelim

### DIFF
--- a/jvcl/run/JvAppIniStorage.pas
+++ b/jvcl/run/JvAppIniStorage.pas
@@ -704,7 +704,7 @@ begin
           IniFile.EraseSection(Sections[I])
       else
         for I := 0 to Sections.Count - 1 do
-          if Pos(TopSection + '\', Sections[I] + '\') = 1 then
+          if Pos(TopSection + PathDelim, Sections[I] + PathDelim) = 1 then
             IniFile.EraseSection(Sections[I]);
       FlushIfNeeded;
     finally


### PR DESCRIPTION
Replace use of '\\' in JvAppIniStorage (added trough #149) by PathDelim, because PathDelim is used throughout the entire AppStorage framework.