### PR TITLE
Update JvComputerInfoEx.pas

### DIFF
--- a/jvcl/run/JvComputerInfoEx.pas
+++ b/jvcl/run/JvComputerInfoEx.pas
@@ -39,7 +39,11 @@ unit JvComputerInfoEx;
 {$I jvcl.inc}
 {$I windowsonly.inc}
 
+{$IFDEF WIN64}
+{$HPPEMIT '#pragma link "wininet.a"'}
+{$ELSE}
 {$HPPEMIT '#pragma link "wininet.lib"'}
+{$ENDIF WIN64}
 
 interface
 


### PR DESCRIPTION
Link in the correct wininet library file when using the C++Builder 64-bit compiler.