### PR TITLE
Update JvUrlGrabbers.pas

### DIFF
--- a/jvcl/run/JvUrlGrabbers.pas
+++ b/jvcl/run/JvUrlGrabbers.pas
@@ -28,7 +28,11 @@ unit JvUrlGrabbers;
 {$I jvcl.inc}
 {$I windowsonly.inc}
 
+{$IFDEF WIN64}
+{$HPPEMIT '#pragma link "wininet.a"'}
+{$ELSE}
 {$HPPEMIT '#pragma link "wininet.lib"'}
+{$ENDIF WIN64}
 
 interface
 


### PR DESCRIPTION
Link in the correct wininet library file when using the C++Builder 64-bit compiler.