### PR TITLE
Update JvUrlListGrabber.pas

### DIFF
--- a/jvcl/run/JvUrlListGrabber.pas
+++ b/jvcl/run/JvUrlListGrabber.pas
@@ -29,7 +29,11 @@ interface
 
 {$I jvcl.inc}
 
+{$IFDEF WIN64}
+{$HPPEMIT '#pragma link "wininet.a"'}
+{$ELSE}
 {$HPPEMIT '#pragma link "wininet.lib"'}
+{$ENDIF WIN64}
 
 uses
   {$IFDEF UNITVERSIONING}


### PR DESCRIPTION
Link in the correct wininet library file when using the C++Builder 64-bit compiler.