### PR TITLE
Bugfix : JvDateEditPicker crashs on Delphi 11

### DIFF
--- a/jvcl/run/JvDatePickerEdit.pas
+++ b/jvcl/run/JvDatePickerEdit.pas
@@ -715,8 +715,8 @@ begin
   Result := ADateFormat;
   StrReplace(Result, 'dd', '00', []);
   StrReplace(Result, 'd', '99', []);
-  StrReplace(Result, 'MM', '00', []);
-  StrReplace(Result, 'M', '99', []);
+  StrReplace(Result, 'MM', '00', [rfIgnoreCase]);
+  StrReplace(Result, 'M', '99', [rfIgnoreCase]);
   StrReplace(Result, 'yyyy', '0099', []);
   StrReplace(Result, 'yy', '00', []);
   StrReplace(Result, ' ', '_', []);
@@ -750,7 +750,7 @@ end;
 
 function TJvCustomDatePickerEdit.DetermineDateSeparator(AFormat: string): Char;
 begin
-  AFormat := StrRemoveChars(Trim(AFormat), ['d', 'M', 'y']);
+  AFormat := StrRemoveChars(Trim(AFormat), ['d', 'm', 'M', 'y']);
   if AFormat <> '' then
     Result := AFormat[1]
   else


### PR DESCRIPTION
It cannot be added onto a Form on Delphi 11 (nor deserialized from DFM) because System `FormatSettings.ShortDateFormat` is now lowercase

So, as the month placeholders "M", "MM", "MMM" and "MMMM" are lowercase, the conversion to Mask strings must take care of that.