### PR TITLE
Fixed TJvHttpUrlGrabber for 64 bit compilation

### DIFF
--- a/jvcl/run/JvUrlGrabbers.pas
+++ b/jvcl/run/JvUrlGrabbers.pas
@@ -367,7 +367,7 @@ begin
 end;
 
 // global download callback
-procedure DownloadCallBack(Handle: HINTERNET; Context: DWORD;
+procedure DownloadCallBack(Handle: HINTERNET; Context: DWORD_PTR;
   AStatus: DWORD; Info: Pointer; StatLen: DWORD); stdcall;
 begin
   with TJvCustomUrlGrabberThread(Context) do


### PR DESCRIPTION
TJvHttpUrlGrabber did not work on 64 bit because there was issue in callback function:
https://docs.microsoft.com/en-us/windows/win32/api/wininet/nc-wininet-internet_status_callback
