### PR TITLE
Only clear 'SelectedRows' when 'ClearSelection' is 'true'

### DIFF
--- a/jvcl/run/JvDBGrid.pas
+++ b/jvcl/run/JvDBGrid.pas
@@ -2748,9 +2748,11 @@ begin
               end
               else
               begin
-                Clear;
                 if FClearSelection then
+                begin
+                  Clear;
                   CurrentRowSelected := True;
+                end;
               end;
             end;
           end;


### PR DESCRIPTION
When using multi-select in a `TJvDBGrid` it does not respect the `ClearSelection` setting, when the mouse is used to navigate the grid