### PR TITLE
Permit attachment with different name using null char as separator

### DIFF
--- a/jvcl/run/JvMail.pas
+++ b/jvcl/run/JvMail.pas
@@ -402,7 +402,7 @@ procedure TJvMail.CreateMapiMessage;
       SetLength(FAttachArray, Attachment.Count);
       for I := 0 to Attachment.Count - 1 do
       begin
-        // Look for #0 splitting parameter in physical filename (lpszPathName) and virtual name (lpszFileName)
+        // Look for #0 splitting parameter in physical filename (PathName) and virtual name (FileName)
         NullPos := Pos(#0, Attachment[I]);
         if NullPos > 0 then
         begin

--- a/jvcl/run/JvMail.pas
+++ b/jvcl/run/JvMail.pas
@@ -402,6 +402,7 @@ procedure TJvMail.CreateMapiMessage;
       SetLength(FAttachArray, Attachment.Count);
       for I := 0 to Attachment.Count - 1 do
       begin
+        // Look for #0 splitting parameter in physical filename (lpszPathName) and virtual name (lpszFileName)
         NullPos := Pos(#0, Attachment[I]);
         if NullPos > 0 then
         begin
@@ -410,6 +411,7 @@ procedure TJvMail.CreateMapiMessage;
         end
         else
         begin
+          // Use real filename in attachment if no #0 is found
           PathName := Attachment[i];
           FileName := ExtractFileName(PathName);
         end;

--- a/jvcl/run/JvMail.pas
+++ b/jvcl/run/JvMail.pas
@@ -394,19 +394,33 @@ procedure TJvMail.CreateMapiMessage;
   procedure MakeAttachments;
   var
     I: Integer;
+    NullPos: Integer;
+    FileName, PathName: string;
   begin
     if Attachment.Count > 0 then
     begin
       SetLength(FAttachArray, Attachment.Count);
       for I := 0 to Attachment.Count - 1 do
       begin
-        if not FileExists(Attachment[I]) then
-          raise EJclMapiError.CreateResFmt(@RsAttachmentNotFound, [Attachment[I]]);
+        NullPos := Pos(#0, Attachment[I]);
+        if NullPos > 0 then
+        begin
+          PathName := Copy(Attachment[i], 0, NullPos - 1);
+          FileName := Copy(Attachment[i], NullPos + 1, Length(Attachment[i]));
+        end
+        else
+        begin
+          PathName := Attachment[i];
+          FileName := ExtractFileName(PathName);
+        end;
+
+        if not FileExists(PathName) then
+          raise EJclMapiError.CreateResFmt(@RsAttachmentNotFound, [PathName]);
 
         FillChar(FAttachArray[I], SizeOf(TMapiFileDesc), #0);
         FAttachArray[I].nPosition := $FFFFFFFF;
-        FAttachArray[I].lpszFileName := StrNewA(PAnsiChar(AnsiString(ExtractFileName(Attachment[I]))));
-        FAttachArray[I].lpszPathName := StrNewA(PAnsiChar(AnsiString(Attachment[I])));
+        FAttachArray[I].lpszFileName := StrNewA(PAnsiChar(AnsiString(FileName)));
+        FAttachArray[I].lpszPathName := StrNewA(PAnsiChar(AnsiString(PathName)));
       end;
     end
     else


### PR DESCRIPTION
As stated in documentation, https://wiki.delphi-jedi.org/wiki/JVCL_Help:TJvMail.Attachment:

> To send an attachment using a different file name, insert a null char (#0) between physical and virtual file names (ie: 'c:pathphysical name.ext'#0'virtualfilename.txt')

Nevertheless, this feature wasn't developed so this PR aims to do so.