### PR TITLE
Corrected the DPI Scaling of the ProgramVersionCheck and ProgramVersionsDescription forms:

### DIFF
--- a/jvcl/run/JvParameterList.pas
+++ b/jvcl/run/JvParameterList.pas
@@ -1684,7 +1684,7 @@ begin
     if (Height <= 0) or (ArrangeSettings.AutoSize in [asHeight, asBoth]) then
       if ArrangePanel.Height + BottomPanel.Height > TForm(ParameterDialog).ClientHeight then
         if ArrangePanel.Height + BottomPanel.Height > MaxHeight then
-          TForm(ParameterDialog).ClientHeight := MaxHeight + 10
+          TForm(ParameterDialog).ClientHeight := MaxHeight + DialogPPIScale(10)
         else
           TForm(ParameterDialog).ClientHeight := ArrangePanel.Height + BottomPanel.Height + DialogPPIScale(10)
       else

--- a/jvcl/run/JvProgramVersionCheck.pas
+++ b/jvcl/run/JvProgramVersionCheck.pas
@@ -1486,6 +1486,7 @@ begin
   ParameterList := TJvParameterList.Create(Self);
   try
     ParameterList.MaxWidth := PPIScale(460);
+    ParameterList.MaxHeight := PPIScale(400);
     ParameterList.Messages.Caption :=
       Format(RsPVCDialogCaption, [CurrentApplicationName]);
     ParameterList.Messages.OkButton := RsPVCDialogExecuteButton;
@@ -1495,7 +1496,7 @@ begin
     Parameter.Caption := Format(RsPVCNewVersionAvailable,
       [GetAllowedRemoteProgramVersionReleaseType, CurrentApplicationName]);
     Parameter.Width := PPIScale(350);
-    Parameter.Height := PPIScale(45);
+    Parameter.Height := PPIScale(35);
     ParameterList.AddParameter(Parameter);
 
     GroupParameter := TJvGroupBoxParameter.Create(ParameterList);
@@ -1516,6 +1517,7 @@ begin
           Parameter.SearchName := SParamNameRadioButton + IntToStr(Ord(I));
           Parameter.Caption := RemoteProgramVersionHistory.CurrentProgramVersion[I].ProgramVersionInfo;
           Parameter.Width := PPIScale(250);
+          Parameter.Height := PPIScale(25);
           Parameter.AsBoolean := GroupParameter.Height <= PPIScale(10);
           ParameterList.AddParameter(Parameter);
 
@@ -1524,11 +1526,10 @@ begin
           Parameter.SearchName := SParamNameVersionButtonInfo + IntToStr(Ord(I));
           Parameter.Caption := RsPVInfoButtonCaption;
           Parameter.Width := PPIScale(80);
+          Parameter.Height := PPIScale(22);
           Parameter.Tag := Ord(I);
           TJvButtonParameter(Parameter).OnClick := VersionInfoButtonClick;
           ParameterList.AddParameter(Parameter);
-
-          GroupParameter.Height := GroupParameter.Height + PPIScale(25);
         end;
     Parameter := TJvBaseParameter(TJvRadioGroupParameter.Create(ParameterList));
     Parameter.SearchName := SParamNameOperation;
@@ -1681,12 +1682,14 @@ var
 begin
   ParameterList := TJvParameterList.Create(Self);
   try
+    ParameterList.MaxWidth := PPIScale(460);
+    ParameterList.MaxHeight := PPIScale(400);
     ParameterList.Messages.Caption := Format(RsPVCWhatNewInS, [CurrentApplicationName]);
     ParameterList.CancelButtonVisible := False;
     Parameter := TJvMemoParameter.Create(ParameterList);
     Parameter.SearchName := SParamNameMemo;
     Parameter.Caption := Format(RsPVCChangesBetween, [AFromVersion, AToVersion]);
-    Parameter.Width := PPIScale(340);
+    Parameter.Width := PPIScale(400);
     Parameter.Height := PPIScale(200);
     Parameter.AsString := RemoteProgramVersionHistory.GetVersionsDescription(AFromVersion, AToVersion);
     Parameter.Scrollbars := ssBoth;


### PR DESCRIPTION
As per title:

The forms on a High Dpi Monitor without the fix:

![image](https://github.com/project-jedi/jvcl/assets/1311616/413f4015-6f7b-492d-93ad-ed37123f21b1)

![image](https://github.com/project-jedi/jvcl/assets/1311616/f2806e94-f8f4-462e-a9cc-46c4e1fafb1e)


The same forms on a High Dpi Monitor with the fix:

![image](https://github.com/project-jedi/jvcl/assets/1311616/a705f1f2-3e7b-45dd-a37d-ea959774c01a)

![image](https://github.com/project-jedi/jvcl/assets/1311616/43128c56-6b19-4ba7-99d5-5581c030ad2e)
