### PR TITLE
Installer compilation error

### DIFF
--- a/jvcl/install/JVCLInstall/Compile.pas
+++ b/jvcl/install/JVCLInstall/Compile.pas
@@ -1224,7 +1224,7 @@ begin
           Files.Add(ExtractFileName(ChangeFileExt(Project.SourceName, '.dpk'))); // readd, dcc removes items from the Files list
           Win64xResult := Dcc(TargetConfig, Project, DccOpt, DebugUnits, Files, nil, True);
           if Win64xResult <> 0 then
-            Exit(Win64xResult);
+            Exit;
         end;
 
         FilesCompiled := True;


### PR DESCRIPTION
While trying to compile the installer using Install.bat, the following error occurs:

Compile.pas(1227) Error: Missing operator or semicolon
Frames\FrmInstall.pas(44) Fatal: Could not compile used unit 'Compile.pas'

The call to the procedure Exit at line 1227 in the Compile.pas unit should be made with no parameters.