### PR TITLE
Fix HiDPI related error in column autosize code in TJvDBGrid

### DIFF
--- a/jvcl/run/JvDBGrid.pas
+++ b/jvcl/run/JvDBGrid.pas
@@ -4320,6 +4320,7 @@ begin
   try
     // Get useable width
     ColLineWidth := Ord(dgColLines in Options) * GridLineWidth;
+    ColLineWidth := PPIScale(Self, ColLineWidth);
     AvailableWidth := ClientWidth;
     if (dgIndicator in Options) then
       Dec(AvailableWidth, PPIScale(Self, IndicatorWidth) + ColLineWidth);


### PR DESCRIPTION
On HiDPI screens column widths are calculated incorrectly in TJvDBGrid. This leads to horizontal scrollbar appearing and grid content scrolling horizontally when user is trying to edit data in last column.