### PR TITLE
corrected behaviour using Ctrl+X or "Cut to clipboard"

### DIFF
--- a/jvcl/run/JvToolEdit.pas
+++ b/jvcl/run/JvToolEdit.pas
@@ -2168,7 +2168,7 @@ end;
 
 procedure TJvCustomComboEdit.WMClear(var Msg: TMessage);
 begin
-  Text := '';
+  SelText := '';
 end;
 
 procedure TJvCustomComboEdit.WMCut(var Msg: TMessage);


### PR DESCRIPTION
the expected is to remove only selected text and not all the text on TJvComboEdit /TJvDBComboEdit
when using Ctrl+X